### PR TITLE
feat(video-analysis): agentic 4-phase VLM pipeline (v2)

### DIFF
--- a/CodeJitsu.Client/src/__tests__/components/AnalysisV2Panel.test.tsx
+++ b/CodeJitsu.Client/src/__tests__/components/AnalysisV2Panel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AnalysisV2Panel from '@/components/VideoAnalysisEditor/v2/AnalysisV2Panel';
+import { AnalysisV2Dto } from '@/types/global';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const analysis: AnalysisV2Dto = {
+  id: 1,
+  videoId: 1,
+  visualDna: 'Athlete in a white gi.',
+  pipelineStatus: 'Complete',
+  technicalGrade: 78,
+  gradeLabel: 'Solid Fundamentals',
+  eliteTip: 'Keep your elbows tight.',
+  matchSummary: 'A competitive match.',
+  matchEvents: [
+    {
+      id: 1, startTimestampMs: 1000, endTimestampMs: 3000, actor: 'Student',
+      techniqueCategory: 'Takedown', techniqueName: 'Double Leg', positionBefore: 'Standing',
+      positionAfter: 'SideControl', outcome: 'Successful', guardType: null, submissionType: null,
+      actionsDescription: 'Clean entry', confidence: 0.9,
+    },
+  ],
+  coachingReport: {
+    id: 1, matchSummary: 'A competitive match.', technicalGrade: 78,
+    gradeLabel: 'Solid Fundamentals', eliteTip: 'Keep your elbows tight.',
+    keyStrengths: [{ title: 'Strong takedowns', explanation: 'Good entries' }],
+    criticalWeaknesses: [{ title: 'Guard retention', explanation: 'Got swept', severity: 'Major', scoringImpact: '2 pts' }],
+    prescribedDrills: [{ drillName: 'Guard retention drill', instructions: 'Retain guard', goal: 'Stop sweeps' }],
+  },
+};
+
+describe('AnalysisV2Panel', () => {
+  it('renders the technical grade and switches tabs', () => {
+    render(<AnalysisV2Panel analysis={analysis} onSeekMs={vi.fn()} onSave={vi.fn()} />);
+
+    // Grade gauge input shows the grade.
+    expect((screen.getByLabelText('technical grade') as HTMLInputElement).value).toBe('78');
+
+    // Switch to the coaching tab.
+    fireEvent.click(screen.getByText('videoReviewV2.tabs.coaching'));
+    expect(screen.getByText('videoReviewV2.coaching.strengthsTitle')).toBeInTheDocument();
+
+    // Switch to the drills tab.
+    fireEvent.click(screen.getByText('videoReviewV2.tabs.drills'));
+    expect(screen.getByText('videoReviewV2.drills.title')).toBeInTheDocument();
+  });
+
+  it('enables Save after an edit and calls onSave with the draft', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<AnalysisV2Panel analysis={analysis} onSeekMs={vi.fn()} onSave={onSave} />);
+
+    const saveBtn = screen.getByText('videoReviewV2.saveChanges').closest('button')!;
+    expect(saveBtn).toBeDisabled();
+
+    // Add a match event → marks the draft dirty.
+    fireEvent.click(screen.getByText(/videoReviewV2.timeline.addEvent/));
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+
+    fireEvent.click(saveBtn);
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const draft = onSave.mock.calls[0][0] as AnalysisV2Dto;
+    expect(draft.matchEvents).toHaveLength(2); // original + added
+  });
+});

--- a/CodeJitsu.Client/src/__tests__/components/MatchEventCard.test.tsx
+++ b/CodeJitsu.Client/src/__tests__/components/MatchEventCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MatchEventCard from '@/components/VideoAnalysisEditor/v2/MatchEventCard';
+import { MatchEvent } from '@/types/global';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const baseEvent: MatchEvent = {
+  id: 1,
+  startTimestampMs: 1000,
+  endTimestampMs: 3000,
+  actor: 'Student',
+  techniqueCategory: 'Takedown',
+  techniqueName: 'Double Leg',
+  positionBefore: 'Standing',
+  positionAfter: 'SideControl',
+  outcome: 'Successful',
+  guardType: null,
+  submissionType: null,
+  actionsDescription: 'Shot a clean double leg',
+  confidence: 0.4, // low confidence
+};
+
+describe('MatchEventCard', () => {
+  it('seeks to the event start when the play button is clicked', () => {
+    const onSeekMs = vi.fn();
+    render(
+      <MatchEventCard event={baseEvent} index={0} onChange={vi.fn()} onDelete={vi.fn()} onSeekMs={onSeekMs} />
+    );
+    // The seek button shows the formatted start time (mm:ss).
+    fireEvent.click(screen.getByText(/00:01/));
+    expect(onSeekMs).toHaveBeenCalledWith(1000);
+  });
+
+  it('flags low-confidence events', () => {
+    render(
+      <MatchEventCard event={baseEvent} index={0} onChange={vi.fn()} onDelete={vi.fn()} onSeekMs={vi.fn()} />
+    );
+    // ConfidenceBadge renders the warning glyph for confidence < 0.7.
+    expect(screen.getByText('⚠')).toBeInTheDocument();
+  });
+
+  it('emits onChange when the actor is edited', () => {
+    const onChange = vi.fn();
+    render(
+      <MatchEventCard event={baseEvent} index={0} onChange={onChange} onDelete={vi.fn()} onSeekMs={vi.fn()} />
+    );
+    // First combobox is the actor select.
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0], { target: { value: 'Opponent' } });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ actor: 'Opponent' }));
+  });
+
+  it('emits onDelete when the remove button is clicked', () => {
+    const onDelete = vi.fn();
+    render(
+      <MatchEventCard event={baseEvent} index={0} onChange={vi.fn()} onDelete={onDelete} onSeekMs={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText('✕'));
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/VideoPlayer.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/VideoPlayer.tsx
@@ -2,6 +2,13 @@ import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } f
 import { Button } from '@/components/ui/button';
 import { TechniqueDto } from '@/types/global';
 
+export interface EventMarker {
+    id: string | number;
+    startMs: number;
+    label: string; // pre-translated by the parent
+    color?: string;
+}
+
 interface VideoPlayerProps {
     videoUrl: string;
     videoId: string;
@@ -10,10 +17,14 @@ interface VideoPlayerProps {
     setSelectedSegment: (segment: { start: string; end: string } | null) => void;
     clearSelection: () => void;
     onSegmentSelect?: (start: string, end: string) => void;
+    // ── V2 (ms-based) additions; legacy callers omit these ──
+    eventMarkers?: EventMarker[];
+    onSegmentSelectMs?: (startMs: number, endMs: number) => void;
 }
 
 export interface VideoPlayerHandle {
     seekTo: (timestamp: string) => void;
+    seekToMs: (ms: number) => void;
 }
 
 const parseTimespanToSeconds = (timestamp: string | null): number => {
@@ -41,6 +52,8 @@ const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(({
     setSelectedSegment,
     clearSelection,
     onSegmentSelect,
+    eventMarkers,
+    onSegmentSelectMs,
 }, ref) => {
     const videoRef = useRef<HTMLVideoElement>(null);
     const timelineRef = useRef<HTMLDivElement>(null);
@@ -53,13 +66,19 @@ const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(({
     const [mouseDownPosition, setMouseDownPosition] = useState<number | null>(null);
     const DRAG_THRESHOLD = 5; // Pixels to consider as a drag
 
-    // Expose seekTo function to parent via ref
+    // Expose seek functions to parent via ref
     useImperativeHandle(ref, () => ({
         seekTo: (timestamp: string) => {
             const seconds = parseTimespanToSeconds(timestamp);
             if (!isNaN(seconds) && videoRef.current) {
                 videoRef.current.pause();
                 videoRef.current.currentTime = seconds;
+            }
+        },
+        seekToMs: (ms: number) => {
+            if (Number.isFinite(ms) && videoRef.current) {
+                videoRef.current.pause();
+                videoRef.current.currentTime = ms / 1000;
             }
         },
     }));
@@ -119,6 +138,7 @@ const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(({
                 const endFormatted = parseSecondsToTimespan(to);
                 setSelectedSegment({ start: startFormatted, end: endFormatted });
                 onSegmentSelect?.(startFormatted, endFormatted);
+                onSegmentSelectMs?.(Math.round(from * 1000), Math.round(to * 1000));
             }
 
             setIsDragging(false);
@@ -315,6 +335,28 @@ const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(({
                                     videoRef.current!.currentTime = timestampNum;
                                 }}
                                 title={`Technique: ${technique.name} (${technique.startTimestamp})`}
+                            />
+                        );
+                    })}
+                    {/* V2 ms-based event markers (color-coded by actor/severity) */}
+                    {(eventMarkers ?? []).map((marker) => {
+                        const seconds = marker.startMs / 1000;
+                        if (!Number.isFinite(seconds) || duration <= 0) return null;
+                        const leftPercent = (seconds / duration) * 100;
+                        return (
+                            <div
+                                key={`evt-${marker.id}`}
+                                className="marker absolute top-0 h-full cursor-pointer"
+                                style={{
+                                    left: `${leftPercent}%`,
+                                    width: '5px',
+                                    backgroundColor: marker.color ?? '#3b82f6',
+                                }}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    videoRef.current!.currentTime = seconds;
+                                }}
+                                title={marker.label}
                             />
                         );
                     })}

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/AnalysisSummaryHeader.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/AnalysisSummaryHeader.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import GradeGauge from './GradeGauge';
+
+interface AnalysisSummaryHeaderProps {
+    visualDna: string;
+    matchSummary: string;
+    gradeLabel: string;
+    eliteTip: string;
+    technicalGrade: number;
+    onChange: (patch: Partial<{
+        visualDna: string;
+        matchSummary: string;
+        gradeLabel: string;
+        eliteTip: string;
+        technicalGrade: number;
+    }>) => void;
+}
+
+const fieldClass = 'w-full text-sm bg-parchment-50 border border-[rgba(60,50,40,0.18)] rounded px-2 py-1 focus:outline-none focus:border-samurai-400';
+
+const AnalysisSummaryHeader: React.FC<AnalysisSummaryHeaderProps> = ({
+    visualDna, matchSummary, gradeLabel, eliteTip, technicalGrade, onChange,
+}) => {
+    const { t } = useTranslation();
+
+    return (
+        <div className="rounded-md border border-[rgba(60,50,40,0.12)] bg-parchment-100 p-4 mb-4">
+            <div className="flex items-start gap-4">
+                <div className="flex flex-col items-center">
+                    <GradeGauge grade={technicalGrade} editable onChange={(g) => onChange({ technicalGrade: g })} />
+                    <span className="mt-1 text-xs text-slate-zen400">{t('videoReviewV2.summary.gradeLabel')}</span>
+                </div>
+                <div className="flex-1 space-y-2">
+                    <label className="block text-xs text-slate-zen400">
+                        {t('videoReviewV2.summary.gradeLabelField')}
+                        <input className={fieldClass} value={gradeLabel} onChange={(e) => onChange({ gradeLabel: e.target.value })} />
+                    </label>
+                    <div className="rounded bg-samurai-50 border-l-4 border-samurai-400 p-2">
+                        <span className="block text-xs font-semibold text-samurai-600">{t('videoReviewV2.summary.eliteTipTitle')}</span>
+                        <input className={`${fieldClass} mt-1`} value={eliteTip} onChange={(e) => onChange({ eliteTip: e.target.value })} />
+                    </div>
+                </div>
+            </div>
+
+            <label className="block text-xs text-slate-zen400 mt-3">
+                {t('videoReviewV2.summary.matchSummaryTitle')}
+                <textarea className={fieldClass} rows={3} value={matchSummary} onChange={(e) => onChange({ matchSummary: e.target.value })} />
+            </label>
+
+            <label className="block text-xs text-slate-zen400 mt-3">
+                {t('videoReviewV2.summary.visualDnaTitle')}
+                <textarea className={fieldClass} rows={3} value={visualDna} onChange={(e) => onChange({ visualDna: e.target.value })} />
+            </label>
+        </div>
+    );
+};
+
+export default AnalysisSummaryHeader;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/AnalysisV2Panel.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/AnalysisV2Panel.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { AnalysisV2Dto, CoachingReport, MatchEvent, KeyStrength, CriticalWeakness, PrescribedDrill } from '@/types/global';
+import AnalysisSummaryHeader from './AnalysisSummaryHeader';
+import MatchTimelineTab from './MatchTimelineTab';
+import CoachingTab from './CoachingTab';
+import PrescribedDrillsTab from './PrescribedDrillsTab';
+
+interface AnalysisV2PanelProps {
+    analysis: AnalysisV2Dto;
+    onSeekMs: (ms: number) => void;
+    onSave: (draft: AnalysisV2Dto) => Promise<void>;
+    isSaving?: boolean;
+    selectedSegmentMs?: { startMs: number; endMs: number } | null;
+}
+
+type Tab = 'timeline' | 'coaching' | 'drills';
+
+const emptyReport = (): CoachingReport => ({
+    matchSummary: '', technicalGrade: 0, gradeLabel: '', eliteTip: '',
+    keyStrengths: [], criticalWeaknesses: [], prescribedDrills: [],
+});
+
+/** Normalises an analysis into an editable draft with a guaranteed coaching report. */
+const toDraft = (a: AnalysisV2Dto): AnalysisV2Dto => ({
+    ...a,
+    visualDna: a.visualDna ?? '',
+    matchEvents: a.matchEvents ?? [],
+    coachingReport: a.coachingReport
+        ? {
+            ...a.coachingReport,
+            keyStrengths: a.coachingReport.keyStrengths ?? [],
+            criticalWeaknesses: a.coachingReport.criticalWeaknesses ?? [],
+            prescribedDrills: a.coachingReport.prescribedDrills ?? [],
+        }
+        : emptyReport(),
+});
+
+const tabButtonClass = (active: boolean) =>
+    `shadcn-ui-tab px-4 py-2 rounded-t-md font-medium transition-colors duration-150 focus:outline-none ` +
+    (active
+        ? 'bg-parchment-100 border-b-2 border-samurai-400 text-samurai-400 shadow-zen-sm'
+        : 'bg-parchment-200 text-slate-zen400 hover:text-ink-400 hover:bg-parchment-300');
+
+const AnalysisV2Panel: React.FC<AnalysisV2PanelProps> = ({ analysis, onSeekMs, onSave, isSaving, selectedSegmentMs }) => {
+    const { t } = useTranslation();
+    const [activeTab, setActiveTab] = useState<Tab>('timeline');
+    const [draft, setDraft] = useState<AnalysisV2Dto>(() => toDraft(analysis));
+    const [dirty, setDirty] = useState(false);
+
+    // Reset the working copy whenever a different analysis (or fresh server data) arrives.
+    useEffect(() => {
+        setDraft(toDraft(analysis));
+        setDirty(false);
+    }, [analysis]);
+
+    const report = draft.coachingReport as CoachingReport;
+
+    const patch = (next: Partial<AnalysisV2Dto>) => { setDraft((d) => ({ ...d, ...next })); setDirty(true); };
+    const patchReport = (next: Partial<CoachingReport>) => {
+        setDraft((d) => ({ ...d, coachingReport: { ...(d.coachingReport as CoachingReport), ...next } }));
+        setDirty(true);
+    };
+
+    const setEvents = (events: MatchEvent[]) => patch({ matchEvents: events });
+    const setStrengths = (keyStrengths: KeyStrength[]) => patchReport({ keyStrengths });
+    const setWeaknesses = (criticalWeaknesses: CriticalWeakness[]) => patchReport({ criticalWeaknesses });
+    const setDrills = (prescribedDrills: PrescribedDrill[]) => patchReport({ prescribedDrills });
+
+    const eventCount = useMemo(() => draft.matchEvents.length, [draft.matchEvents]);
+
+    return (
+        <div className="feedback-container p-4 rounded-md shadow-zen-md border border-[rgba(60,50,40,0.10)]">
+            <AnalysisSummaryHeader
+                visualDna={draft.visualDna ?? ''}
+                matchSummary={report.matchSummary}
+                gradeLabel={report.gradeLabel ?? ''}
+                eliteTip={report.eliteTip ?? ''}
+                technicalGrade={report.technicalGrade}
+                onChange={(p) => {
+                    if ('visualDna' in p) patch({ visualDna: p.visualDna });
+                    const reportPatch: Partial<CoachingReport> = {};
+                    if ('matchSummary' in p) reportPatch.matchSummary = p.matchSummary;
+                    if ('gradeLabel' in p) reportPatch.gradeLabel = p.gradeLabel;
+                    if ('eliteTip' in p) reportPatch.eliteTip = p.eliteTip;
+                    if ('technicalGrade' in p) reportPatch.technicalGrade = p.technicalGrade as number;
+                    if (Object.keys(reportPatch).length > 0) patchReport(reportPatch);
+                }}
+            />
+
+            <div className="flex space-x-2 border-b mb-4">
+                <button type="button" className={tabButtonClass(activeTab === 'timeline')} onClick={() => setActiveTab('timeline')}>
+                    {t('videoReviewV2.tabs.timeline')} ({eventCount})
+                </button>
+                <button type="button" className={tabButtonClass(activeTab === 'coaching')} onClick={() => setActiveTab('coaching')}>
+                    {t('videoReviewV2.tabs.coaching')}
+                </button>
+                <button type="button" className={tabButtonClass(activeTab === 'drills')} onClick={() => setActiveTab('drills')}>
+                    {t('videoReviewV2.tabs.drills')}
+                </button>
+            </div>
+
+            <div className="mt-4">
+                {activeTab === 'timeline' && (
+                    <MatchTimelineTab events={draft.matchEvents} onChange={setEvents} onSeekMs={onSeekMs} selectedSegmentMs={selectedSegmentMs} />
+                )}
+                {activeTab === 'coaching' && (
+                    <CoachingTab
+                        strengths={report.keyStrengths}
+                        weaknesses={report.criticalWeaknesses}
+                        onChangeStrengths={setStrengths}
+                        onChangeWeaknesses={setWeaknesses}
+                        onSeekMs={onSeekMs}
+                    />
+                )}
+                {activeTab === 'drills' && (
+                    <PrescribedDrillsTab drills={report.prescribedDrills} onChange={setDrills} />
+                )}
+            </div>
+
+            <div className="mt-4 flex items-center justify-end gap-3">
+                {dirty && <span className="text-xs text-amber-600">{t('videoReviewV2.unsavedChanges')}</span>}
+                <Button type="button" disabled={isSaving || !dirty} onClick={() => onSave(draft)}>
+                    {isSaving ? t('videoReviewV2.saving') : t('videoReviewV2.saveChanges')}
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default AnalysisV2Panel;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/CoachingTab.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/CoachingTab.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { KeyStrength, CriticalWeakness, WeaknessSeverity } from '@/types/global';
+import { severityKey, severityBadgeClass, formatMs, ALL_SEVERITIES } from './enumLabels';
+
+interface CoachingTabProps {
+    strengths: KeyStrength[];
+    weaknesses: CriticalWeakness[];
+    onChangeStrengths: (s: KeyStrength[]) => void;
+    onChangeWeaknesses: (w: CriticalWeakness[]) => void;
+    onSeekMs: (ms: number) => void;
+}
+
+const fieldClass = 'w-full text-sm bg-parchment-50 border border-[rgba(60,50,40,0.18)] rounded px-2 py-1 focus:outline-none focus:border-samurai-400';
+
+const CoachingTab: React.FC<CoachingTabProps> = ({ strengths, weaknesses, onChangeStrengths, onChangeWeaknesses, onSeekMs }) => {
+    const { t } = useTranslation();
+
+    const setStrength = (i: number, next: KeyStrength) => onChangeStrengths(strengths.map((s, idx) => (idx === i ? next : s)));
+    const setWeakness = (i: number, next: CriticalWeakness) => onChangeWeaknesses(weaknesses.map((w, idx) => (idx === i ? next : w)));
+
+    return (
+        <div className="space-y-6">
+            {/* Strengths */}
+            <section>
+                <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-serif text-lg font-bold text-green-700">{t('videoReviewV2.coaching.strengthsTitle')}</h3>
+                    <Button type="button" size="sm" onClick={() => onChangeStrengths([...strengths, { title: '', explanation: '' }])}>
+                        + {t('videoReviewV2.coaching.addStrength')}
+                    </Button>
+                </div>
+                {strengths.length === 0 ? (
+                    <p className="text-sm text-slate-zen400">{t('videoReviewV2.coaching.noStrengths')}</p>
+                ) : strengths.map((s, i) => (
+                    <div key={i} className="rounded-md border border-[rgba(60,50,40,0.12)] bg-parchment-100 p-3 mb-2">
+                        <div className="flex items-center gap-2 mb-1">
+                            <input className={fieldClass} placeholder={t('videoReviewV2.coaching.titlePlaceholder')} value={s.title} onChange={(e) => setStrength(i, { ...s, title: e.target.value })} />
+                            {s.timestampStartMs != null && (
+                                <Button type="button" size="sm" variant="secondary" onClick={() => onSeekMs(s.timestampStartMs!)}>▶ {formatMs(s.timestampStartMs)}</Button>
+                            )}
+                            <Button type="button" size="sm" variant="secondary" className="text-blood-500" onClick={() => onChangeStrengths(strengths.filter((_, idx) => idx !== i))}>✕</Button>
+                        </div>
+                        <textarea className={fieldClass} rows={2} value={s.explanation ?? ''} onChange={(e) => setStrength(i, { ...s, explanation: e.target.value })} />
+                    </div>
+                ))}
+            </section>
+
+            {/* Weaknesses */}
+            <section>
+                <div className="flex items-center justify-between mb-2">
+                    <h3 className="font-serif text-lg font-bold text-blood-600">{t('videoReviewV2.coaching.weaknessesTitle')}</h3>
+                    <Button type="button" size="sm" onClick={() => onChangeWeaknesses([...weaknesses, { title: '', explanation: '', severity: 'Major' }])}>
+                        + {t('videoReviewV2.coaching.addWeakness')}
+                    </Button>
+                </div>
+                {weaknesses.length === 0 ? (
+                    <p className="text-sm text-slate-zen400">{t('videoReviewV2.coaching.noWeaknesses')}</p>
+                ) : weaknesses.map((w, i) => (
+                    <div key={i} className="rounded-md border border-[rgba(60,50,40,0.12)] bg-parchment-100 p-3 mb-2">
+                        <div className="flex items-center gap-2 mb-1">
+                            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${severityBadgeClass[w.severity]}`}>{t(severityKey(w.severity))}</span>
+                            <input className={fieldClass} placeholder={t('videoReviewV2.coaching.titlePlaceholder')} value={w.title} onChange={(e) => setWeakness(i, { ...w, title: e.target.value })} />
+                            {w.timestampStartMs != null && (
+                                <Button type="button" size="sm" variant="secondary" onClick={() => onSeekMs(w.timestampStartMs!)}>▶ {formatMs(w.timestampStartMs)}</Button>
+                            )}
+                            <Button type="button" size="sm" variant="secondary" className="text-blood-500" onClick={() => onChangeWeaknesses(weaknesses.filter((_, idx) => idx !== i))}>✕</Button>
+                        </div>
+                        <textarea className={fieldClass} rows={2} value={w.explanation ?? ''} onChange={(e) => setWeakness(i, { ...w, explanation: e.target.value })} />
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-2">
+                            <label className="text-xs text-slate-zen400">
+                                {t('videoReviewV2.coaching.severity')}
+                                <select className={fieldClass} value={w.severity} onChange={(e) => setWeakness(i, { ...w, severity: e.target.value as WeaknessSeverity })}>
+                                    {ALL_SEVERITIES.map((sev) => <option key={sev} value={sev}>{t(severityKey(sev))}</option>)}
+                                </select>
+                            </label>
+                            <label className="text-xs text-slate-zen400">
+                                {t('videoReviewV2.coaching.scoringImpact')}
+                                <input className={fieldClass} value={w.scoringImpact ?? ''} onChange={(e) => setWeakness(i, { ...w, scoringImpact: e.target.value })} />
+                            </label>
+                        </div>
+                    </div>
+                ))}
+            </section>
+        </div>
+    );
+};
+
+export default CoachingTab;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/ConfidenceBadge.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/ConfidenceBadge.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LOW_CONFIDENCE_THRESHOLD } from './enumLabels';
+
+interface ConfidenceBadgeProps {
+    confidence: number; // 0.0 - 1.0
+}
+
+/** Shows confidence as a percentage and flags low-confidence (<0.7) events for review. */
+const ConfidenceBadge: React.FC<ConfidenceBadgeProps> = ({ confidence }) => {
+    const { t } = useTranslation();
+    const pct = Math.round((confidence ?? 0) * 100);
+    const isLow = (confidence ?? 0) < LOW_CONFIDENCE_THRESHOLD;
+
+    return (
+        <span
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                isLow ? 'bg-amber-100 text-amber-700' : 'bg-parchment-200 text-slate-zen400'
+            }`}
+            title={isLow ? t('videoReviewV2.confidence.lowTooltip') : undefined}
+        >
+            {t('videoReviewV2.confidence.label', { percent: pct })}
+            {isLow && <span aria-label={t('videoReviewV2.confidence.low')}>⚠</span>}
+        </span>
+    );
+};
+
+export default ConfidenceBadge;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/GradeGauge.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/GradeGauge.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface GradeGaugeProps {
+    grade: number; // 0-100
+    editable?: boolean;
+    onChange?: (grade: number) => void;
+}
+
+const gradeColor = (g: number): string => {
+    if (g >= 80) return 'text-green-600 border-green-500';
+    if (g >= 60) return 'text-samurai-400 border-samurai-400';
+    if (g >= 40) return 'text-amber-600 border-amber-500';
+    return 'text-blood-600 border-blood-500';
+};
+
+/** Compact 0-100 technical grade indicator. Editable variant renders a number input. */
+const GradeGauge: React.FC<GradeGaugeProps> = ({ grade, editable, onChange }) => {
+    const clamped = Math.max(0, Math.min(100, Math.round(grade ?? 0)));
+    return (
+        <div className={`flex items-center justify-center w-20 h-20 rounded-full border-4 ${gradeColor(clamped)}`}>
+            {editable ? (
+                <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={clamped}
+                    onChange={(e) => onChange?.(Math.max(0, Math.min(100, Number(e.target.value))))}
+                    className="w-12 text-2xl font-bold text-center bg-transparent focus:outline-none"
+                    aria-label="technical grade"
+                />
+            ) : (
+                <span className="text-2xl font-bold">{clamped}</span>
+            )}
+        </div>
+    );
+};
+
+export default GradeGauge;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/MatchEventCard.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/MatchEventCard.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { MatchEvent, Actor, TechniqueCategory, Position, Outcome } from '@/types/global';
+import ConfidenceBadge from './ConfidenceBadge';
+import {
+    actorKey, techniqueCategoryKey, positionKey, outcomeKey,
+    actorBadgeClass, outcomeBadgeClass, formatMs,
+    ALL_ACTORS, ALL_TECHNIQUE_CATEGORIES, ALL_POSITIONS, ALL_OUTCOMES,
+} from './enumLabels';
+
+interface MatchEventCardProps {
+    event: MatchEvent;
+    index: number;
+    onChange: (next: MatchEvent) => void;
+    onDelete: () => void;
+    onSeekMs: (ms: number) => void;
+    selectedSegmentMs?: { startMs: number; endMs: number } | null;
+}
+
+const fieldClass = 'w-full text-sm bg-parchment-50 border border-[rgba(60,50,40,0.18)] rounded px-2 py-1 focus:outline-none focus:border-samurai-400';
+
+const MatchEventCard: React.FC<MatchEventCardProps> = ({ event, onChange, onDelete, onSeekMs, selectedSegmentMs }) => {
+    const { t } = useTranslation();
+    const set = <K extends keyof MatchEvent>(key: K, value: MatchEvent[K]) => onChange({ ...event, [key]: value });
+
+    return (
+        <div className="rounded-md border border-[rgba(60,50,40,0.12)] bg-parchment-100 p-3 mb-3">
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${actorBadgeClass[event.actor]}`}>
+                        {t(actorKey(event.actor))}
+                    </span>
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${outcomeBadgeClass[event.outcome]}`}>
+                        {t(outcomeKey(event.outcome))}
+                    </span>
+                    <ConfidenceBadge confidence={event.confidence} />
+                </div>
+                <div className="flex items-center gap-2">
+                    <Button type="button" size="sm" variant="secondary" onClick={() => onSeekMs(event.startTimestampMs)}>
+                        ▶ {formatMs(event.startTimestampMs)}
+                    </Button>
+                    <Button type="button" size="sm" variant="secondary" className="text-blood-500" onClick={onDelete}>
+                        ✕
+                    </Button>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.enums.actor.Student')}/{t('videoReviewV2.enums.actor.Opponent')}
+                    <select className={fieldClass} value={event.actor} onChange={(e) => set('actor', e.target.value as Actor)}>
+                        {ALL_ACTORS.map((a) => <option key={a} value={a}>{t(actorKey(a))}</option>)}
+                    </select>
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.category')}
+                    <select className={fieldClass} value={event.techniqueCategory} onChange={(e) => set('techniqueCategory', e.target.value as TechniqueCategory)}>
+                        {ALL_TECHNIQUE_CATEGORIES.map((c) => <option key={c} value={c}>{t(techniqueCategoryKey(c))}</option>)}
+                    </select>
+                </label>
+                <label className="text-xs text-slate-zen400 sm:col-span-2">
+                    {t('videoReviewV2.event.techniqueName')}
+                    <input className={fieldClass} value={event.techniqueName ?? ''} onChange={(e) => set('techniqueName', e.target.value)} />
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.positionBefore')}
+                    <select className={fieldClass} value={event.positionBefore ?? ''} onChange={(e) => set('positionBefore', e.target.value as Position)}>
+                        <option value="">—</option>
+                        {ALL_POSITIONS.map((p) => <option key={p} value={p}>{t(positionKey(p))}</option>)}
+                    </select>
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.positionAfter')}
+                    <select className={fieldClass} value={event.positionAfter ?? ''} onChange={(e) => set('positionAfter', e.target.value as Position)}>
+                        <option value="">—</option>
+                        {ALL_POSITIONS.map((p) => <option key={p} value={p}>{t(positionKey(p))}</option>)}
+                    </select>
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.outcome')}
+                    <select className={fieldClass} value={event.outcome} onChange={(e) => set('outcome', e.target.value as Outcome)}>
+                        {ALL_OUTCOMES.map((o) => <option key={o} value={o}>{t(outcomeKey(o))}</option>)}
+                    </select>
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.guardType')}
+                    <input className={fieldClass} value={event.guardType ?? ''} onChange={(e) => set('guardType', e.target.value)} />
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.startMs')}
+                    <input type="number" className={fieldClass} value={event.startTimestampMs} onChange={(e) => set('startTimestampMs', Number(e.target.value))} />
+                </label>
+                <label className="text-xs text-slate-zen400">
+                    {t('videoReviewV2.event.endMs')}
+                    <input type="number" className={fieldClass} value={event.endTimestampMs} onChange={(e) => set('endTimestampMs', Number(e.target.value))} />
+                </label>
+                <label className="text-xs text-slate-zen400 sm:col-span-2">
+                    {t('videoReviewV2.event.submissionType')}
+                    <input className={fieldClass} value={event.submissionType ?? ''} onChange={(e) => set('submissionType', e.target.value)} />
+                </label>
+                <label className="text-xs text-slate-zen400 sm:col-span-2">
+                    {t('videoReviewV2.timeline.actionsTitle')}
+                    <textarea className={fieldClass} rows={2} value={event.actionsDescription ?? ''} onChange={(e) => set('actionsDescription', e.target.value)} />
+                </label>
+            </div>
+
+            {selectedSegmentMs && (
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    className="mt-2"
+                    onClick={() => onChange({ ...event, startTimestampMs: selectedSegmentMs.startMs, endTimestampMs: selectedSegmentMs.endMs })}
+                >
+                    {t('videoReviewV2.event.useSelection')}
+                </Button>
+            )}
+        </div>
+    );
+};
+
+export default MatchEventCard;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/MatchTimelineTab.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/MatchTimelineTab.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { MatchEvent } from '@/types/global';
+import MatchEventCard from './MatchEventCard';
+
+interface MatchTimelineTabProps {
+    events: MatchEvent[];
+    onChange: (events: MatchEvent[]) => void;
+    onSeekMs: (ms: number) => void;
+    selectedSegmentMs?: { startMs: number; endMs: number } | null;
+}
+
+const newEvent = (selection?: { startMs: number; endMs: number } | null): MatchEvent => ({
+    startTimestampMs: selection?.startMs ?? 0,
+    endTimestampMs: selection?.endMs ?? 0,
+    actor: 'Student',
+    techniqueCategory: 'Transition',
+    techniqueName: '',
+    positionBefore: null,
+    positionAfter: null,
+    outcome: 'InProgress',
+    guardType: null,
+    submissionType: null,
+    actionsDescription: '',
+    confidence: 1.0,
+});
+
+const MatchTimelineTab: React.FC<MatchTimelineTabProps> = ({ events, onChange, onSeekMs, selectedSegmentMs }) => {
+    const { t } = useTranslation();
+
+    const updateAt = (index: number, next: MatchEvent) => {
+        const copy = [...events];
+        copy[index] = next;
+        onChange(copy);
+    };
+    const deleteAt = (index: number) => onChange(events.filter((_, i) => i !== index));
+    const add = () => onChange([...events, newEvent(selectedSegmentMs)]);
+
+    const sorted = [...events]
+        .map((e, originalIndex) => ({ e, originalIndex }))
+        .sort((a, b) => a.e.startTimestampMs - b.e.startTimestampMs);
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="font-serif text-lg font-bold text-ink-400">{t('videoReviewV2.tabs.timeline')}</h3>
+                <Button type="button" size="sm" onClick={add}>+ {t('videoReviewV2.timeline.addEvent')}</Button>
+            </div>
+
+            {events.length === 0 ? (
+                <p className="text-sm text-slate-zen400">{t('videoReviewV2.timeline.empty')}</p>
+            ) : (
+                sorted.map(({ e, originalIndex }) => (
+                    <MatchEventCard
+                        key={originalIndex}
+                        event={e}
+                        index={originalIndex}
+                        onChange={(next) => updateAt(originalIndex, next)}
+                        onDelete={() => deleteAt(originalIndex)}
+                        onSeekMs={onSeekMs}
+                        selectedSegmentMs={selectedSegmentMs}
+                    />
+                ))
+            )}
+        </div>
+    );
+};
+
+export default MatchTimelineTab;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/PrescribedDrillsTab.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/PrescribedDrillsTab.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { PrescribedDrill } from '@/types/global';
+
+interface PrescribedDrillsTabProps {
+    drills: PrescribedDrill[];
+    onChange: (drills: PrescribedDrill[]) => void;
+}
+
+const fieldClass = 'w-full text-sm bg-parchment-50 border border-[rgba(60,50,40,0.18)] rounded px-2 py-1 focus:outline-none focus:border-samurai-400';
+
+const PrescribedDrillsTab: React.FC<PrescribedDrillsTabProps> = ({ drills, onChange }) => {
+    const { t } = useTranslation();
+    const setAt = (i: number, next: PrescribedDrill) => onChange(drills.map((d, idx) => (idx === i ? next : d)));
+
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-3">
+                <h3 className="font-serif text-lg font-bold text-ink-400">{t('videoReviewV2.drills.title')}</h3>
+                <Button type="button" size="sm" onClick={() => onChange([...drills, { drillName: '', instructions: '', goal: '' }])}>
+                    + {t('videoReviewV2.drills.addDrill')}
+                </Button>
+            </div>
+
+            {drills.length === 0 ? (
+                <p className="text-sm text-slate-zen400">{t('videoReviewV2.drills.empty')}</p>
+            ) : drills.map((d, i) => (
+                <div key={i} className="rounded-md border border-[rgba(60,50,40,0.12)] bg-parchment-100 p-3 mb-3">
+                    <div className="flex items-center gap-2 mb-2">
+                        <input className={fieldClass} placeholder={t('videoReviewV2.drills.namePlaceholder')} value={d.drillName} onChange={(e) => setAt(i, { ...d, drillName: e.target.value })} />
+                        <Button type="button" size="sm" variant="secondary" className="text-blood-500" onClick={() => onChange(drills.filter((_, idx) => idx !== i))}>✕</Button>
+                    </div>
+                    <label className="text-xs text-slate-zen400 block mb-2">
+                        {t('videoReviewV2.drills.goalLabel')}
+                        <input className={fieldClass} value={d.goal ?? ''} onChange={(e) => setAt(i, { ...d, goal: e.target.value })} />
+                    </label>
+                    <label className="text-xs text-slate-zen400 block">
+                        {t('videoReviewV2.drills.instructionsLabel')}
+                        <textarea className={fieldClass} rows={2} value={d.instructions ?? ''} onChange={(e) => setAt(i, { ...d, instructions: e.target.value })} />
+                    </label>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default PrescribedDrillsTab;

--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/enumLabels.ts
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/v2/enumLabels.ts
@@ -1,0 +1,56 @@
+// Enum → i18n key helpers (all display text lives in the locale files) plus color/threshold maps.
+
+export const techniqueCategoryKey = (c: string) => `videoReviewV2.enums.techniqueCategory.${c}`;
+export const positionKey = (p: string) => `videoReviewV2.enums.position.${p}`;
+export const outcomeKey = (o: string) => `videoReviewV2.enums.outcome.${o}`;
+export const actorKey = (a: string) => `videoReviewV2.enums.actor.${a}`;
+export const severityKey = (s: string) => `videoReviewV2.enums.severity.${s}`;
+
+export const ALL_TECHNIQUE_CATEGORIES = [
+    'Takedown', 'Submission', 'Sweep', 'Pass', 'Escape', 'Transition',
+    'Control', 'Defense', 'GuardPull', 'Scramble', 'StandUp', 'GripFight',
+] as const;
+
+export const ALL_POSITIONS = [
+    'Standing', 'OpenGuard', 'ClosedGuard', 'HalfGuard', 'SideControl', 'Mount',
+    'BackControl', 'Turtle', 'KneeOnBelly', 'NorthSouth', 'FiftyFifty', 'Crucifix', 'Scramble',
+] as const;
+
+export const ALL_OUTCOMES = ['Successful', 'Failed', 'Partial', 'Countered', 'InProgress'] as const;
+export const ALL_ACTORS = ['Student', 'Opponent'] as const;
+export const ALL_SEVERITIES = ['Critical', 'Major', 'Minor'] as const;
+
+export const outcomeBadgeClass: Record<string, string> = {
+    Successful: 'bg-green-100 text-green-700',
+    Failed: 'bg-blood-100 text-blood-600',
+    Partial: 'bg-amber-100 text-amber-700',
+    Countered: 'bg-orange-100 text-orange-700',
+    InProgress: 'bg-parchment-200 text-slate-zen400',
+};
+
+export const actorBadgeClass: Record<string, string> = {
+    Student: 'bg-blue-100 text-blue-700',
+    Opponent: 'bg-red-100 text-red-700',
+};
+
+export const actorMarkerColor: Record<string, string> = {
+    Student: '#3b82f6', // blue
+    Opponent: '#ef4444', // red
+};
+
+export const severityBadgeClass: Record<string, string> = {
+    Critical: 'bg-blood-100 text-blood-700',
+    Major: 'bg-amber-100 text-amber-700',
+    Minor: 'bg-parchment-200 text-slate-zen400',
+};
+
+export const LOW_CONFIDENCE_THRESHOLD = 0.7;
+
+/** Formats absolute milliseconds as mm:ss for compact display. */
+export const formatMs = (ms: number): string => {
+    if (!Number.isFinite(ms) || ms < 0) ms = 0;
+    const totalSeconds = Math.floor(ms / 1000);
+    const mins = Math.floor(totalSeconds / 60);
+    const secs = totalSeconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+};

--- a/CodeJitsu.Client/src/locales/en/translation.json
+++ b/CodeJitsu.Client/src/locales/en/translation.json
@@ -1,5 +1,97 @@
 ﻿{
   "translation": {
+    "videoReviewV2": {
+      "page": { "title": "Review and edit this tape" },
+      "saveChanges": "Save Changes",
+      "saving": "Saving...",
+      "unsavedChanges": "Unsaved changes",
+      "tabs": {
+        "timeline": "Match Timeline",
+        "coaching": "Coaching Report",
+        "drills": "Prescribed Drills"
+      },
+      "summary": {
+        "visualDnaTitle": "Athlete Profile (Visual DNA)",
+        "matchSummaryTitle": "Match Summary",
+        "gradeLabel": "Technical Grade",
+        "gradeLabelField": "Grade Label",
+        "eliteTipTitle": "Elite Tip"
+      },
+      "timeline": {
+        "addEvent": "Add Event",
+        "empty": "No match events were detected.",
+        "actionsTitle": "What happened"
+      },
+      "event": {
+        "category": "Category",
+        "techniqueName": "Technique",
+        "positionBefore": "Position before",
+        "positionAfter": "Position after",
+        "outcome": "Outcome",
+        "guardType": "Guard type",
+        "submissionType": "Submission type",
+        "startMs": "Start (ms)",
+        "endMs": "End (ms)",
+        "useSelection": "Use timeline selection"
+      },
+      "coaching": {
+        "strengthsTitle": "Key Strengths",
+        "weaknessesTitle": "Critical Weaknesses",
+        "addStrength": "Add Strength",
+        "addWeakness": "Add Weakness",
+        "severity": "Severity",
+        "scoringImpact": "Scoring impact",
+        "titlePlaceholder": "Title",
+        "noStrengths": "No standout strengths identified.",
+        "noWeaknesses": "No critical weaknesses identified."
+      },
+      "drills": {
+        "title": "Prescribed Drills",
+        "addDrill": "Add Drill",
+        "goalLabel": "Goal",
+        "instructionsLabel": "Instructions",
+        "namePlaceholder": "Drill name",
+        "empty": "No drills were prescribed."
+      },
+      "confidence": {
+        "label": "Confidence: {{percent}}%",
+        "low": "Low confidence",
+        "lowTooltip": "The model is less certain about this event."
+      },
+      "progress": {
+        "starting": "Starting analysis...",
+        "profiling": "Identifying your athlete...",
+        "logging": "Analyzing positions & transitions...",
+        "verifying": "Verifying identity tracking...",
+        "coaching": "Crafting your coach notes...",
+        "complete": "Analysis complete",
+        "completeTitle": "Analysis Completed",
+        "failed": "Analysis failed",
+        "failedTitle": "Analysis Failed",
+        "failedBody": "There was an error analyzing your video. Please try again."
+      },
+      "enums": {
+        "actor": { "Student": "Student", "Opponent": "Opponent" },
+        "techniqueCategory": {
+          "Takedown": "Takedown", "Submission": "Submission", "Sweep": "Sweep",
+          "Pass": "Pass", "Escape": "Escape", "Transition": "Transition",
+          "Control": "Control", "Defense": "Defense", "GuardPull": "Guard Pull",
+          "Scramble": "Scramble", "StandUp": "Stand Up", "GripFight": "Grip Fight"
+        },
+        "position": {
+          "Standing": "Standing", "OpenGuard": "Open Guard", "ClosedGuard": "Closed Guard",
+          "HalfGuard": "Half Guard", "SideControl": "Side Control", "Mount": "Mount",
+          "BackControl": "Back Control", "Turtle": "Turtle", "KneeOnBelly": "Knee on Belly",
+          "NorthSouth": "North-South", "FiftyFifty": "50/50", "Crucifix": "Crucifix",
+          "Scramble": "Scramble"
+        },
+        "outcome": {
+          "Successful": "Successful", "Failed": "Failed", "Partial": "Partial",
+          "Countered": "Countered", "InProgress": "In Progress"
+        },
+        "severity": { "Critical": "Critical", "Major": "Major", "Minor": "Minor" }
+      }
+    },
     "app.title": "Sample Asp.Net Core - React Docker App",
     "navbar.about": "About",
     "navbar.login": "Login",

--- a/CodeJitsu.Client/src/locales/pl/translation.json
+++ b/CodeJitsu.Client/src/locales/pl/translation.json
@@ -1,5 +1,97 @@
 ﻿{
   "translation": {
+    "videoReviewV2": {
+      "page": { "title": "Przejrzyj i edytuj to nagranie" },
+      "saveChanges": "Zapisz zmiany",
+      "saving": "Zapisywanie...",
+      "unsavedChanges": "Niezapisane zmiany",
+      "tabs": {
+        "timeline": "Oś czasu walki",
+        "coaching": "Raport trenerski",
+        "drills": "Zalecane ćwiczenia"
+      },
+      "summary": {
+        "visualDnaTitle": "Profil zawodnika (Visual DNA)",
+        "matchSummaryTitle": "Podsumowanie walki",
+        "gradeLabel": "Ocena techniczna",
+        "gradeLabelField": "Etykieta oceny",
+        "eliteTipTitle": "Wskazówka eksperta"
+      },
+      "timeline": {
+        "addEvent": "Dodaj zdarzenie",
+        "empty": "Nie wykryto żadnych zdarzeń.",
+        "actionsTitle": "Co się wydarzyło"
+      },
+      "event": {
+        "category": "Kategoria",
+        "techniqueName": "Technika",
+        "positionBefore": "Pozycja przed",
+        "positionAfter": "Pozycja po",
+        "outcome": "Rezultat",
+        "guardType": "Typ gardy",
+        "submissionType": "Typ poddania",
+        "startMs": "Początek (ms)",
+        "endMs": "Koniec (ms)",
+        "useSelection": "Użyj zaznaczenia z osi czasu"
+      },
+      "coaching": {
+        "strengthsTitle": "Kluczowe mocne strony",
+        "weaknessesTitle": "Krytyczne słabości",
+        "addStrength": "Dodaj mocną stronę",
+        "addWeakness": "Dodaj słabość",
+        "severity": "Waga",
+        "scoringImpact": "Wpływ na punktację",
+        "titlePlaceholder": "Tytuł",
+        "noStrengths": "Nie zidentyfikowano wyróżniających mocnych stron.",
+        "noWeaknesses": "Nie zidentyfikowano krytycznych słabości."
+      },
+      "drills": {
+        "title": "Zalecane ćwiczenia",
+        "addDrill": "Dodaj ćwiczenie",
+        "goalLabel": "Cel",
+        "instructionsLabel": "Instrukcje",
+        "namePlaceholder": "Nazwa ćwiczenia",
+        "empty": "Nie zalecono żadnych ćwiczeń."
+      },
+      "confidence": {
+        "label": "Pewność: {{percent}}%",
+        "low": "Niska pewność",
+        "lowTooltip": "Model jest mniej pewny tego zdarzenia."
+      },
+      "progress": {
+        "starting": "Rozpoczynanie analizy...",
+        "profiling": "Identyfikacja zawodnika...",
+        "logging": "Analiza pozycji i przejść...",
+        "verifying": "Weryfikacja śledzenia tożsamości...",
+        "coaching": "Tworzenie notatek trenerskich...",
+        "complete": "Analiza zakończona",
+        "completeTitle": "Analiza zakończona",
+        "failed": "Analiza nie powiodła się",
+        "failedTitle": "Analiza nie powiodła się",
+        "failedBody": "Wystąpił błąd podczas analizy filmu. Spróbuj ponownie."
+      },
+      "enums": {
+        "actor": { "Student": "Zawodnik", "Opponent": "Przeciwnik" },
+        "techniqueCategory": {
+          "Takedown": "Obalenie", "Submission": "Poddanie", "Sweep": "Przewrót",
+          "Pass": "Przejście gardy", "Escape": "Ucieczka", "Transition": "Przejście",
+          "Control": "Kontrola", "Defense": "Obrona", "GuardPull": "Ściągnięcie do gardy",
+          "Scramble": "Walka o pozycję", "StandUp": "Powstanie", "GripFight": "Walka o chwyty"
+        },
+        "position": {
+          "Standing": "Stójka", "OpenGuard": "Otwarta garda", "ClosedGuard": "Zamknięta garda",
+          "HalfGuard": "Półgarda", "SideControl": "Pozycja boczna", "Mount": "Dosiad",
+          "BackControl": "Kontrola pleców", "Turtle": "Żółw", "KneeOnBelly": "Kolano na brzuchu",
+          "NorthSouth": "Północ-południe", "FiftyFifty": "50/50", "Crucifix": "Krucyfiks",
+          "Scramble": "Walka o pozycję"
+        },
+        "outcome": {
+          "Successful": "Udane", "Failed": "Nieudane", "Partial": "Częściowe",
+          "Countered": "Skontrowane", "InProgress": "W trakcie"
+        },
+        "severity": { "Critical": "Krytyczna", "Major": "Poważna", "Minor": "Drobna" }
+      }
+    },
     "app.title": "Demonstracyjna aplikacja Asp.Net Core - React Docker",
     "navbar.about": "O nas",
     "navbar.login": "Zaloguj się",

--- a/CodeJitsu.Client/src/pages/VideoAnalysisManagement.tsx
+++ b/CodeJitsu.Client/src/pages/VideoAnalysisManagement.tsx
@@ -3,14 +3,19 @@ import VideoUploadForm from '../components/VideoAnalysisEditor/VideoUploadForm';
 import VideoStorageListing from './VideoStorageListing';
 import { VideoUploadResponse } from '@/types/global';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useToast } from '@/hooks/use-toast';
 import { analysisConnection } from '../services/SignalRService';
 import * as signalR from '@microsoft/signalr';
 
+const V2_ENABLED = import.meta.env.VITE_ANALYSIS_V2_ENABLED !== 'false';
+
 const VideoAnalysisManagement: React.FC = () => {
     const { user, accessToken, hydrate } = useAuthStore();
+    const { t } = useTranslation();
     const [isUploading, setIsUploading] = useState(false);
     const [isAnalyzing, setIsAnalyzing] = useState(false);
+    const [analysisPhase, setAnalysisPhase] = useState<string | null>(null);
     const [shouldRefreshList, setShouldRefreshList] = useState(false);
     const { toast } = useToast();
     const [isConnected, setIsConnected] = useState(false);
@@ -20,7 +25,7 @@ const VideoAnalysisManagement: React.FC = () => {
             analysisConnection.start().then(() => {
                 console.log('Connected to SignalR hub');
                 setIsConnected(true);
-                // Listen for the AnalysisCompleted event from the server.
+                // Legacy single-shot completion.
                 analysisConnection.on("AnalysisCompleted", (videoId: number) => {
                     toast({
                         title: "Analysis Completed",
@@ -28,6 +33,29 @@ const VideoAnalysisManagement: React.FC = () => {
                         variant: "default",
                     });
                     setShouldRefreshList(true);
+                });
+                // Agentic (v2) per-phase progress.
+                analysisConnection.on("AnalysisStatusChanged", (_videoId: number, phase: string) => {
+                    setAnalysisPhase(phase);
+                });
+                analysisConnection.on("AnalysisV2Completed", (videoId: number) => {
+                    setAnalysisPhase(null);
+                    setIsAnalyzing(false);
+                    toast({
+                        title: t('videoReviewV2.progress.completeTitle'),
+                        description: `Video ${videoId} analysis is complete.`,
+                        variant: "default",
+                    });
+                    setShouldRefreshList(true);
+                });
+                analysisConnection.on("AnalysisV2Failed", (_videoId: number) => {
+                    setAnalysisPhase(null);
+                    setIsAnalyzing(false);
+                    toast({
+                        title: t('videoReviewV2.progress.failedTitle'),
+                        description: t('videoReviewV2.progress.failedBody'),
+                        variant: "destructive",
+                    });
                 });
             }).catch((err) => console.error("SignalR Connection Error on /analysisHub: ", err));
         }
@@ -38,12 +66,13 @@ const VideoAnalysisManagement: React.FC = () => {
                 setIsConnected(false);
             }
         };
-    }, [toast]);
+    }, [toast, t]);
 
     const handleUploadSuccess = async (response: VideoUploadResponse) => {
         try {
             setIsAnalyzing(true);
-            const res = await fetch(`/vid/api/video/analyze/${response.videoId}`, {
+            const analyzePath = V2_ENABLED ? 'analyze-v2' : 'analyze';
+            const res = await fetch(`/vid/api/video/${analyzePath}/${response.videoId}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -95,10 +124,14 @@ const VideoAnalysisManagement: React.FC = () => {
                                 onUploadSuccess={handleUploadSuccess}
                             />
                         </div>
-                        {isAnalyzing && (
+                        {(isAnalyzing || analysisPhase) && (
                             <div className="mt-4 flex items-center space-x-2">
                                 <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-samurai-400"></div>
-                                <p className="text-samurai-400">AI is analyzing the video. This may take a few minutes...</p>
+                                <p className="text-samurai-400">
+                                    {analysisPhase
+                                        ? t(`videoReviewV2.progress.${analysisPhase.toLowerCase()}`)
+                                        : t('videoReviewV2.progress.starting')}
+                                </p>
                             </div>
                         )}
                     </div>

--- a/CodeJitsu.Client/src/pages/VideoReview.tsx
+++ b/CodeJitsu.Client/src/pages/VideoReview.tsx
@@ -1,56 +1,61 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { getFighterDetails, getVideoDetails, getVideoFeedback, saveVideoAnalysisResult } from '@/services/api';
-import VideoPlayer, { VideoPlayerHandle } from '../components/VideoAnalysisEditor/VideoPlayer';
+import { useTranslation } from 'react-i18next';
+import {
+    getFighterDetails, getVideoDetails, getVideoFeedback, saveVideoAnalysisResult,
+    getVideoAnalysisV2, saveVideoAnalysisV2,
+} from '@/services/api';
+import VideoPlayer, { VideoPlayerHandle, EventMarker } from '../components/VideoAnalysisEditor/VideoPlayer';
 import useAuthStore from '@/store/authStore';
-import { AnalysisResultDto, Fighter } from '@/types/global';
+import { AnalysisResultDto, AnalysisV2Dto, Fighter } from '@/types/global';
 import { StudentDetails } from '@/components/VideoAnalysisEditor/StudentFighterDetails';
 import TechniqueFeedback from '@/components/VideoAnalysisEditor/TechniqueFeedback';
+import AnalysisV2Panel from '@/components/VideoAnalysisEditor/v2/AnalysisV2Panel';
+import { actorMarkerColor, techniqueCategoryKey } from '@/components/VideoAnalysisEditor/v2/enumLabels';
+
+const V2_ENABLED = import.meta.env.VITE_ANALYSIS_V2_ENABLED !== 'false';
 
 const VideoReview: React.FC = () => {
     const { videoId } = useParams<{ videoId: string }>();
+    const { t } = useTranslation();
     const [feedbackList, setFeedbackList] = useState<AnalysisResultDto | null>(null);
+    const [analysisV2, setAnalysisV2] = useState<AnalysisV2Dto | null>(null);
     const [videoUrl, setVideoUrl] = useState('');
     const { accessToken, refreshToken, hydrate } = useAuthStore();
 
     const [selectedSegment, setSelectedSegment] = useState<{ start: string; end: string } | null>(null);
+    const [selectedSegmentMs, setSelectedSegmentMs] = useState<{ startMs: number; endMs: number } | null>(null);
     const [fighterDetails, setFighterDetails] = useState<Fighter | null>(null);
     const videoPlayerRef = useRef<VideoPlayerHandle>(null);
     const [studentIdentifier, setStudentIdentifier] = useState<string | null>(null);
-    const [isAnalysisSaving , setIsAnalysisSaving] = useState(false);
+    const [isAnalysisSaving, setIsAnalysisSaving] = useState(false);
 
     useEffect(() => {
         if (!videoId) return;
 
         const fetchData = async () => {
             try {
-                const videoDetails = await getVideoDetails({
-                    videoId,
-                    jwtToken: accessToken,
-                    refreshToken,
-                    hydrate,
-                });
-                console.log('Video Details:', videoDetails);
+                const videoDetails = await getVideoDetails({ videoId, jwtToken: accessToken, refreshToken, hydrate });
                 setVideoUrl(videoDetails.signedUrl);
                 setStudentIdentifier(videoDetails.studentIdentifier);
 
-                const feedbackData: AnalysisResultDto = await getVideoFeedback({
-                    videoId,
-                    jwtToken: accessToken,
-                    refreshToken,
-                    hydrate,
-                });
-                setFeedbackList(feedbackData);
-                //console.log('AiAnalysisResultDto data:', feedbackData);
+                // Prefer the richer v2 analysis; fall back to the legacy editor when absent.
+                let usedV2 = false;
+                if (V2_ENABLED) {
+                    try {
+                        const v2 = await getVideoAnalysisV2({ videoId, jwtToken: accessToken, refreshToken, hydrate });
+                        if (v2) { setAnalysisV2(v2); usedV2 = true; }
+                    } catch (e) {
+                        console.warn('v2 analysis fetch failed, falling back to legacy:', e);
+                    }
+                }
+                if (!usedV2) {
+                    const feedbackData: AnalysisResultDto = await getVideoFeedback({ videoId, jwtToken: accessToken, refreshToken, hydrate });
+                    setFeedbackList(feedbackData);
+                }
 
-                const fighterDetails = await getFighterDetails({
-                    fighterId: videoDetails.fighterId,
-                    jwtToken: accessToken,
-                    refreshToken,
-                    hydrate,
-                })
-                setFighterDetails(fighterDetails ?? null);
-                console.log("Video details: ", videoDetails);
+                const fd = await getFighterDetails({ fighterId: videoDetails.fighterId, jwtToken: accessToken, refreshToken, hydrate });
+                setFighterDetails(fd ?? null);
             } catch (error) {
                 console.error('Error fetching data:', error);
             }
@@ -59,12 +64,7 @@ const VideoReview: React.FC = () => {
         fetchData();
     }, [videoId, accessToken, refreshToken, hydrate]);
 
-    const handleInputChange = (
-        section: string,
-        index: string | number,
-        field: string | number,
-        value: any
-    ) => {
+    const handleInputChange = (section: string, index: string | number, field: string | number, value: any) => {
         const updatedAnalysis = { ...feedbackList } as any;
         if (section === 'overallAnalysis') {
             updatedAnalysis[section][field] = value;
@@ -75,22 +75,13 @@ const VideoReview: React.FC = () => {
     };
 
     const handleSaveAnalysisResult = async (partialFeedbackData: AnalysisResultDto) => {
-        if (!partialFeedbackData || !videoId) {
-            console.error('Missing videoId or PartialAnalysisResultDto for saving.');
-            return;
-        }
-
+        if (!partialFeedbackData || !videoId) return;
         try {
             setIsAnalysisSaving(true);
-            const updatedAnalysisResult = await saveVideoAnalysisResult({
-                videoId,
-                analysisResultBody: partialFeedbackData,
-                jwtToken: accessToken,
-                refreshToken,
-                hydrate,
+            const updated = await saveVideoAnalysisResult({
+                videoId, analysisResultBody: partialFeedbackData, jwtToken: accessToken, refreshToken, hydrate,
             });
-
-            setFeedbackList(updatedAnalysisResult);
+            setFeedbackList(updated);
             alert('Changes saved successfully!');
         } catch (error: any) {
             console.error('Save operation failed:', error);
@@ -100,19 +91,34 @@ const VideoReview: React.FC = () => {
         }
     };
 
-    const handleSeek = (timestamp: string) => {
-        if (videoPlayerRef.current) {
-            videoPlayerRef.current.seekTo(timestamp);
+    const handleSaveV2 = async (draft: AnalysisV2Dto) => {
+        if (!videoId) return;
+        try {
+            setIsAnalysisSaving(true);
+            const updated = await saveVideoAnalysisV2({ videoId, analysisBody: draft, jwtToken: accessToken, hydrate });
+            setAnalysisV2(updated);
+        } catch (error: any) {
+            console.error('Save (v2) failed:', error);
+            alert(`Error saving changes: ${error.message || 'Unknown error'}`);
+        } finally {
+            setIsAnalysisSaving(false);
         }
     };
 
-    const clearSelection = () => {
-        setSelectedSegment(null);
-    };
+    const handleSeek = (timestamp: string) => videoPlayerRef.current?.seekTo(timestamp);
+    const handleSeekMs = (ms: number) => videoPlayerRef.current?.seekToMs(ms);
+    const clearSelection = () => { setSelectedSegment(null); setSelectedSegmentMs(null); };
+
+    const eventMarkers: EventMarker[] = (analysisV2?.matchEvents ?? []).map((e, i) => ({
+        id: e.id ?? i,
+        startMs: e.startTimestampMs,
+        label: e.techniqueName || t(techniqueCategoryKey(e.techniqueCategory)),
+        color: actorMarkerColor[e.actor],
+    }));
 
     return (
         <div className="w-full">
-            <h1 className="font-serif text-3xl font-bold text-center mt-3 text-ink-400">Review and edit this tape</h1>
+            <h1 className="font-serif text-3xl font-bold text-center mt-3 text-ink-400">{t('videoReviewV2.page.title')}</h1>
             <div className="flex flex-col md:flex-row gap-4 md:p-4 m-0 md:m-2">
                 <div className="w-full md:w-1/2 flex flex-col gap-4">
                     <div className="rounded-lg shadow-zen-sm bg-parchment-50 border border-[rgba(60,50,40,0.10)] p-2 md:p-4">
@@ -120,11 +126,13 @@ const VideoReview: React.FC = () => {
                             ref={videoPlayerRef}
                             videoUrl={videoUrl}
                             videoId={videoId || '0'}
-                            identifiedTechniques={feedbackList?.techniques || []}
+                            identifiedTechniques={analysisV2 ? [] : (feedbackList?.techniques || [])}
                             selectedSegment={selectedSegment}
                             setSelectedSegment={setSelectedSegment}
                             clearSelection={clearSelection}
                             onSegmentSelect={(start, end) => setSelectedSegment({ start, end })}
+                            eventMarkers={analysisV2 ? eventMarkers : undefined}
+                            onSegmentSelectMs={(startMs, endMs) => setSelectedSegmentMs({ startMs, endMs })}
                         />
                     </div>
                     <div className="rounded-lg shadow-zen-sm bg-parchment-50 border border-[rgba(60,50,40,0.10)] p-2 md:p-4">
@@ -133,14 +141,24 @@ const VideoReview: React.FC = () => {
                 </div>
                 <div className="w-full md:w-1/2 mt-4 md:mt-0">
                     <div className="rounded-lg shadow-zen-sm bg-parchment-50 border border-[rgba(60,50,40,0.10)] p-2 md:p-4 h-full">
-                        <TechniqueFeedback
-                            feedbackData={feedbackList}
-                            onSeek={handleSeek}
-                            saveChanges={handleSaveAnalysisResult}
-                            onInputChange={handleInputChange}
-                            selectedSegment={selectedSegment}
-                            isAnalysisSaving={isAnalysisSaving}
-                        />
+                        {analysisV2 ? (
+                            <AnalysisV2Panel
+                                analysis={analysisV2}
+                                onSeekMs={handleSeekMs}
+                                onSave={handleSaveV2}
+                                isSaving={isAnalysisSaving}
+                                selectedSegmentMs={selectedSegmentMs}
+                            />
+                        ) : (
+                            <TechniqueFeedback
+                                feedbackData={feedbackList}
+                                onSeek={handleSeek}
+                                saveChanges={handleSaveAnalysisResult}
+                                onInputChange={handleInputChange}
+                                selectedSegment={selectedSegment}
+                                isAnalysisSaving={isAnalysisSaving}
+                            />
+                        )}
                     </div>
                 </div>
             </div>

--- a/CodeJitsu.Client/src/services/api.ts
+++ b/CodeJitsu.Client/src/services/api.ts
@@ -17,6 +17,7 @@ import {
     FighterInfo,
     Fighter,
     AnalysisResultDto,
+    AnalysisV2Dto,
     CurriculumDto,
     TakeAttendanceRequest,
     TakeAttendanceResponse,
@@ -646,6 +647,71 @@ export async function saveVideoAnalysisResult({
         throw new Error(`Failed to save analysis result: ${response.statusText}`);
     }
 
+    return await response.json();
+}
+
+// ── V2 (agentic pipeline) analysis ──────────────────────────────────────────
+
+export async function getVideoAnalysisV2({
+    videoId,
+    jwtToken,
+    refreshToken,
+    hydrate,
+    currentTry = 0,
+}: {
+    videoId: string;
+    jwtToken: string | null;
+    refreshToken: string | null;
+    hydrate: () => Promise<void>;
+    currentTry?: number;
+}): Promise<AnalysisV2Dto | null> {
+    const response = await fetch(`/vid/api/video/${videoId}/analysis-v2`, {
+        headers: { Authorization: `Bearer ${jwtToken}` },
+    });
+
+    if (response.status === 404) {
+        // No v2 analysis for this video → caller falls back to the legacy view.
+        return null;
+    }
+    if (response.ok) {
+        return await response.json();
+    }
+    if (response.status === 401 && currentTry === 0) {
+        await hydrate();
+        return await getVideoAnalysisV2({ videoId, jwtToken, refreshToken, hydrate, currentTry: 1 });
+    }
+    throw new Error(`Error fetching v2 analysis: ${response.statusText}`);
+}
+
+export async function saveVideoAnalysisV2({
+    videoId,
+    analysisBody,
+    jwtToken,
+    hydrate,
+    currentTry = 0,
+}: {
+    videoId: string;
+    analysisBody: AnalysisV2Dto;
+    jwtToken: string | null;
+    hydrate: () => Promise<void>;
+    currentTry?: number;
+}): Promise<AnalysisV2Dto> {
+    const response = await fetch(`/vid/api/video/${videoId}/analysis-v2`, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${jwtToken}`,
+        },
+        body: JSON.stringify(analysisBody),
+    });
+
+    if (response.status === 401 && currentTry === 0) {
+        await hydrate();
+        return await saveVideoAnalysisV2({ videoId, analysisBody, jwtToken, hydrate, currentTry: 1 });
+    }
+    if (!response.ok) {
+        throw new Error(`Failed to save v2 analysis: ${response.statusText}`);
+    }
     return await response.json();
 }
 

--- a/CodeJitsu.Client/src/types/global.ts
+++ b/CodeJitsu.Client/src/types/global.ts
@@ -310,6 +310,102 @@ export interface AnalysisResultDto {
     techniques?: TechniqueDto[] | null; // Updated to use TechniqueDto
 }
 
+// ── V2 (agentic pipeline) analysis result ───────────────────────────────────
+// Timestamps are absolute integer milliseconds (distinct from the legacy HH:mm:ss path).
+
+export type Actor = 'Student' | 'Opponent';
+
+export type TechniqueCategory =
+    | 'Takedown' | 'Submission' | 'Sweep' | 'Pass' | 'Escape'
+    | 'Transition' | 'Control' | 'Defense' | 'GuardPull'
+    | 'Scramble' | 'StandUp' | 'GripFight';
+
+export type Position =
+    | 'Standing' | 'OpenGuard' | 'ClosedGuard' | 'HalfGuard'
+    | 'SideControl' | 'Mount' | 'BackControl' | 'Turtle'
+    | 'KneeOnBelly' | 'NorthSouth' | 'FiftyFifty' | 'Crucifix' | 'Scramble';
+
+export type Outcome = 'Successful' | 'Failed' | 'Partial' | 'Countered' | 'InProgress';
+
+export type WeaknessSeverity = 'Critical' | 'Major' | 'Minor';
+
+export type AnalysisPipelinePhase =
+    | 'NotStarted' | 'Profiling' | 'Logging' | 'Verifying' | 'Coaching' | 'Complete' | 'Failed';
+
+export interface MatchEvent {
+    id?: number | null;
+    startTimestampMs: number;
+    endTimestampMs: number;
+    actor: Actor;
+    techniqueCategory: TechniqueCategory;
+    techniqueName?: string | null;
+    positionBefore?: Position | null;
+    positionAfter?: Position | null;
+    outcome: Outcome;
+    guardType?: string | null;
+    submissionType?: string | null;
+    actionsDescription?: string | null;
+    confidence: number; // 0.0 - 1.0
+}
+
+export interface KeyStrength {
+    id?: number | null;
+    title: string;
+    explanation?: string | null;
+    timestampStartMs?: number | null;
+    timestampEndMs?: number | null;
+}
+
+export interface CriticalWeakness {
+    id?: number | null;
+    title: string;
+    explanation?: string | null;
+    timestampStartMs?: number | null;
+    timestampEndMs?: number | null;
+    severity: WeaknessSeverity;
+    scoringImpact?: string | null;
+}
+
+export interface PrescribedDrill {
+    id?: number | null;
+    drillName: string;
+    instructions?: string | null;
+    goal?: string | null;
+}
+
+export interface CoachingReport {
+    id?: number | null;
+    matchSummary: string;
+    technicalGrade: number; // 0-100
+    gradeLabel?: string | null;
+    eliteTip?: string | null;
+    keyStrengths: KeyStrength[];
+    criticalWeaknesses: CriticalWeakness[];
+    prescribedDrills: PrescribedDrill[];
+}
+
+export interface AnalysisV2Dto {
+    id?: number | null;
+    videoId: number;
+    visualDna?: string | null;
+    pipelineStatus: AnalysisPipelinePhase;
+    technicalGrade?: number | null;
+    gradeLabel?: string | null;
+    eliteTip?: string | null;
+    matchSummary?: string | null;
+    matchEvents: MatchEvent[];
+    coachingReport?: CoachingReport | null;
+}
+
+/** True when a fetched payload is the richer v2 analysis (vs. the legacy AnalysisResultDto). */
+export function isAnalysisV2(
+    data: AnalysisResultDto | AnalysisV2Dto | null | undefined
+): data is AnalysisV2Dto {
+    return !!data
+        && Array.isArray((data as AnalysisV2Dto).matchEvents)
+        && 'pipelineStatus' in (data as AnalysisV2Dto);
+}
+
 
 export interface CurriculumDto {
     session_title: string;

--- a/CodeJitsu.Tests/VideoAnalysis/Controllers/GeminiControllerTests.cs
+++ b/CodeJitsu.Tests/VideoAnalysis/Controllers/GeminiControllerTests.cs
@@ -2,12 +2,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using CodeJitsu.Tests.Helpers;
 using SharedEntities.Data;
 using SharedEntities.Models;
 using System.Security.Claims;
+using VideoAnalysis.Server.Configuration;
 using VideoAnalysis.Server.Controllers;
+using VideoAnalysis.Server.Domain.AIServices;
 using VideoAnalysis.Server.Domain.GeminiService;
 using VideoAnalysis.Server.Models.Dtos;
 
@@ -25,19 +28,23 @@ public class GeminiControllerTests
         var gemini = geminiMock?.Object ?? new Mock<IGeminiVisionService>().Object;
         services.AddScoped<IGeminiVisionService>(_ => gemini);
         services.AddScoped<CurriculumRecommendationService>();
+        services.AddScoped<AgenticAnalysisReadService>();
+        services.AddScoped<AgenticAnalysisWriteService>();
         return services.BuildServiceProvider();
     }
 
     private static GeminiController CreateController(
         MyDatabaseContext db,
         Mock<IGeminiVisionService>? geminiMock = null,
-        string? authUserId = "test-user-id")
+        string? authUserId = "test-user-id",
+        VertexAiPipelineOptions? pipelineOptions = null)
     {
         geminiMock ??= new Mock<IGeminiVisionService>();
         var loggerMock = new Mock<ILogger<GeminiController>>();
         var serviceProvider = BuildServiceProvider(db, geminiMock);
+        var options = Options.Create(pipelineOptions ?? new VertexAiPipelineOptions());
 
-        var controller = new GeminiController(geminiMock.Object, serviceProvider, loggerMock.Object);
+        var controller = new GeminiController(geminiMock.Object, serviceProvider, loggerMock.Object, options);
 
         var claims = new List<Claim>();
         if (authUserId != null)
@@ -319,6 +326,98 @@ public class GeminiControllerTests
         var ok = Assert.IsType<OkObjectResult>(result);
         var response = Assert.IsType<MatchMakerResponse>(ok.Value);
         Assert.True(response.IsSuccessfullyParsed);
+    }
+
+    // â”€â”€ Agentic (v2) endpoints â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+
+    [Fact]
+    public async Task Should_ReturnBadRequest_When_AnalyzeV2WithUnknownVideo()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db);
+
+        var result = await controller.AnalyzeVideoV2Async(999);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Should_ReturnBadRequest_When_AnalyzeV2AndPipelineDisabled()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db, pipelineOptions: new VertexAiPipelineOptions { Enabled = false });
+
+        var result = await controller.AnalyzeVideoV2Async(1);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Should_ReturnNotFound_When_GetAnalysisV2AndNoV2Analysis()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db);
+
+        var result = await controller.GetVideoAnalysisV2(1);
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Should_ReturnNotStarted_When_GetStatusAndNoAnalysisRow()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db);
+
+        var result = await controller.GetAnalysisStatus(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<AnalysisStatusDto>(ok.Value);
+        Assert.Equal(AnalysisPipelineStatus.NotStarted.ToString(), dto.Status);
+    }
+
+    [Fact]
+    public async Task Should_ReturnPersistedStatus_When_GetStatusForExistingAnalysis()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        db.AiAnalysisResults.Add(new AiAnalysisResult
+        {
+            VideoId = 1,
+            AnalysisJson = "{}",
+            Strengths = "[]",
+            AreasForImprovement = "[]",
+            PipelineStatus = AnalysisPipelineStatus.Coaching,
+        });
+        db.SaveChanges();
+        var controller = CreateController(db);
+
+        var result = await controller.GetAnalysisStatus(1);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var dto = Assert.IsType<AnalysisStatusDto>(ok.Value);
+        Assert.Equal(AnalysisPipelineStatus.Coaching.ToString(), dto.Status);
+    }
+
+    [Fact]
+    public async Task Should_ReturnBadRequest_When_UpdateAnalysisV2BodyIsNull()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db);
+
+        var result = await controller.UpdateAnalysisV2Async(1, null!);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+    }
+
+    [Fact]
+    public async Task Should_ReturnNotFound_When_UpdateAnalysisV2AndNoAnalysis()
+    {
+        var db = InMemoryDbContextFactory.Create();
+        var controller = CreateController(db);
+
+        var result = await controller.UpdateAnalysisV2Async(1, new AnalysisV2Dto { VideoId = 1 });
+
+        Assert.IsType<NotFoundObjectResult>(result.Result);
     }
 }
 

--- a/CodeJitsu.Tests/VideoAnalysis/Services/AgenticAnalysisServiceTests.cs
+++ b/CodeJitsu.Tests/VideoAnalysis/Services/AgenticAnalysisServiceTests.cs
@@ -1,0 +1,126 @@
+using Microsoft.EntityFrameworkCore;
+using CodeJitsu.Tests.Helpers;
+using SharedEntities.Data;
+using SharedEntities.Models;
+using VideoAnalysis.Server.Domain.AIServices;
+using VideoAnalysis.Server.Models.Dtos;
+
+namespace CodeJitsu.Tests.VideoAnalysis.Services;
+
+public class AgenticAnalysisServiceTests
+{
+    private static async Task<AiAnalysisResult> SeedCompleteAnalysisAsync(MyDatabaseContext db, int videoId = 1)
+    {
+        var result = new AiAnalysisResult
+        {
+            VideoId = videoId,
+            AnalysisJson = "{}",
+            Strengths = "[]",
+            AreasForImprovement = "[]",
+            PipelineStatus = AnalysisPipelineStatus.Complete,
+            VisualDna = "Athlete in white gi.",
+            TechnicalGrade = 80,
+            GradeLabel = "Solid",
+            EliteTip = "Tip",
+            MatchSummary = "Summary",
+            MatchEvents =
+            [
+                new MatchEvent { StartTimestampMs = 5000, EndTimestampMs = 6000, Actor = EventActor.Opponent, TechniqueCategory = "Sweep", Outcome = EventOutcome.Successful, Confidence = 0.4, SequenceIndex = 1 },
+                new MatchEvent { StartTimestampMs = 1000, EndTimestampMs = 2000, Actor = EventActor.Student, TechniqueCategory = "Takedown", Outcome = EventOutcome.Successful, Confidence = 0.9, SequenceIndex = 0 },
+            ],
+            CoachingReport = new CoachingReport
+            {
+                MatchSummary = "Summary",
+                TechnicalGrade = 80,
+                GradeLabel = "Solid",
+                EliteTip = "Tip",
+                Strengths = [new CoachingStrength { Title = "Takedowns", Explanation = "Good", SortOrder = 0 }],
+                Weaknesses = [new CoachingWeakness { Title = "Guard", Severity = WeaknessSeverity.Critical, ScoringImpact = "2 pts", SortOrder = 0 }],
+                PrescribedDrills = [new PrescribedDrill { DrillName = "Drill A", Goal = "Goal", SortOrder = 0 }],
+            },
+        };
+        db.AiAnalysisResults.Add(result);
+        await db.SaveChangesAsync();
+        return result;
+    }
+
+    [Fact]
+    public async Task ReadService_Should_MapAndOrderEvents_BySequenceIndex()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        await SeedCompleteAnalysisAsync(db);
+        var read = new AgenticAnalysisReadService(db);
+
+        var dto = await read.GetAnalysisV2DtoByVideoId(1);
+
+        Assert.Equal("Athlete in white gi.", dto.VisualDna);
+        Assert.Equal("Complete", dto.PipelineStatus);
+        Assert.Equal(2, dto.MatchEvents.Count);
+        Assert.Equal("Student", dto.MatchEvents[0].Actor);        // SequenceIndex 0 first
+        Assert.Equal("Takedown", dto.MatchEvents[0].TechniqueCategory);
+        Assert.NotNull(dto.CoachingReport);
+        Assert.Equal("Critical", dto.CoachingReport!.CriticalWeaknesses[0].Severity);
+        Assert.Single(dto.CoachingReport!.PrescribedDrills);
+    }
+
+    [Fact]
+    public async Task ReadService_Should_Throw_When_NoV2Analysis()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var read = new AgenticAnalysisReadService(db);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => read.GetAnalysisV2DtoByVideoId(999));
+    }
+
+    [Fact]
+    public async Task WriteService_Should_UpsertEvents_AndReplaceCoachingReport()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        await SeedCompleteAnalysisAsync(db);
+        var write = new AgenticAnalysisWriteService(db);
+
+        var dto = new AnalysisV2Dto
+        {
+            VideoId = 1,
+            VisualDna = "Edited DNA",
+            MatchEvents =
+            [
+                new MatchEventDto { StartTimestampMs = 100, EndTimestampMs = 200, Actor = "Student", TechniqueCategory = "Pass", Outcome = "Partial", Confidence = 0.7 },
+            ],
+            CoachingReport = new CoachingReportDto
+            {
+                MatchSummary = "Edited summary",
+                TechnicalGrade = 95,
+                GradeLabel = "Excellent",
+                EliteTip = "New tip",
+                KeyStrengths = [new CoachingStrengthDto { Title = "S1" }, new CoachingStrengthDto { Title = "S2" }],
+                CriticalWeaknesses = [new CoachingWeaknessDto { Title = "W1", Severity = "Minor" }],
+                PrescribedDrills = [new PrescribedDrillDto { DrillName = "D1" }],
+            },
+        };
+
+        var updated = await write.SaveAnalysisV2(1, dto, userId: "editor-1");
+
+        Assert.Equal("Edited DNA", updated.VisualDna);
+        Assert.Single(updated.MatchEvents);                       // 2 → 1 (delete handled)
+        Assert.Equal("Pass", updated.MatchEvents[0].TechniqueCategory);
+        Assert.Equal(95, updated.CoachingReport!.TechnicalGrade);
+        Assert.Equal(2, updated.CoachingReport!.KeyStrengths.Count);
+        Assert.Equal("Minor", updated.CoachingReport!.CriticalWeaknesses[0].Severity);
+
+        // Mirrored headline fields updated on the analysis row.
+        var row = await db.AiAnalysisResults.AsNoTracking().FirstAsync(a => a.VideoId == 1);
+        Assert.Equal(95, row.TechnicalGrade);
+        Assert.Equal("Excellent", row.GradeLabel);
+    }
+
+    [Fact]
+    public async Task WriteService_Should_Throw_When_NoAnalysisRow()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var write = new AgenticAnalysisWriteService(db);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => write.SaveAnalysisV2(999, new AnalysisV2Dto { VideoId = 999 }, null));
+    }
+}

--- a/CodeJitsu.Tests/VideoAnalysis/Services/AgenticPipelineServiceTests.cs
+++ b/CodeJitsu.Tests/VideoAnalysis/Services/AgenticPipelineServiceTests.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using CodeJitsu.Tests.Helpers;
+using SharedEntities.Data;
+using SharedEntities.Models;
+using VideoAnalysis.Server.Configuration;
+using VideoAnalysis.Server.Domain.AIServices;
+using VideoAnalysis.Server.Domain.YoutubeSharingService;
+
+namespace CodeJitsu.Tests.VideoAnalysis.Services;
+
+public class AgenticPipelineServiceTests
+{
+    private const string VisualDna = "A muscular athlete in a navy-blue gi with a white belt and red athletic tape on both hands.";
+
+    private const string EventsJson = """
+        {"events":[
+          {"start_timestamp_ms":1000,"end_timestamp_ms":3000,"actor":"Student","technique_category":"Takedown","technique_name":"Double Leg","position_before":"Standing","position_after":"SideControl","outcome":"Successful","guard_type":null,"submission_type":null,"actions_description":"Shot a double leg","confidence":0.9},
+          {"start_timestamp_ms":5000,"end_timestamp_ms":7000,"actor":"Opponent","technique_category":"Sweep","technique_name":"Scissor Sweep","position_before":"ClosedGuard","position_after":"Mount","outcome":"Successful","guard_type":"ClosedGuard","submission_type":null,"actions_description":"Swept from guard","confidence":0.4}
+        ]}
+        """;
+
+    private const string CoachingJson = """
+        {"match_summary":"A competitive match with strong takedowns.","technical_grade":78,"grade_label":"Solid Fundamentals","elite_tip":"Keep your elbows tight during the scramble.",
+         "key_strengths":[{"title":"Strong takedowns","explanation":"Clean double leg entry","timestamp_start_ms":1000,"timestamp_end_ms":3000}],
+         "critical_weaknesses":[{"title":"Guard retention","explanation":"Got swept from closed guard","timestamp_start_ms":5000,"timestamp_end_ms":7000,"severity":"Major","scoring_impact":"2 points conceded"}],
+         "prescribed_drills":[
+           {"drill_name":"Guard retention drill","instructions":"Retain guard against passing","goal":"Stop sweeps"},
+           {"drill_name":"Takedown entries","instructions":"Drill doubles","goal":"Improve entries"},
+           {"drill_name":"Sweep defense","instructions":"Maintain base","goal":"Defend sweeps"}
+         ]}
+        """;
+
+    private static async Task<int> SeedAsync(MyDatabaseContext db, int videoId = 1)
+    {
+        var fighter = TestFixtures.CreateFighter(id: 1, beltColor: BeltColor.Blue);
+        db.Fighters.Add(fighter);
+        var user = TestFixtures.CreateAppUser(id: "user-1", fighterId: 1);
+        db.Users.Add(user);
+        var video = TestFixtures.CreateStudentUploadMetadata(id: videoId, userId: "user-1");
+        db.Videos.Add(video);
+        await db.SaveChangesAsync();
+        return videoId;
+    }
+
+    private static (AgenticPipelineService svc, Mock<IVertexRestClient> vertex, List<string> sent)
+        CreateService(MyDatabaseContext db, Action<Mock<IVertexRestClient>> configureVertex, VertexAiPipelineOptions? opts = null)
+    {
+        var vertex = new Mock<IVertexRestClient>();
+        vertex.Setup(v => v.ModelResourcePath(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns("projects/p/locations/us-central1/publishers/google/models/m");
+        vertex.Setup(v => v.GenerateContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(default(JsonElement));
+        configureVertex(vertex);
+
+        var sent = new List<string>();
+        var clientProxy = new Mock<IClientProxy>();
+        clientProxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((method, args, _) =>
+                sent.Add(args.Length > 1 ? $"{method}:{args[1]}" : method))
+            .Returns(Task.CompletedTask);
+        var clients = new Mock<IHubClients>();
+        clients.Setup(c => c.All).Returns(clientProxy.Object);
+        var hub = new Mock<IHubContext<VideoAnalysisHub>>();
+        hub.Setup(h => h.Clients).Returns(clients.Object);
+
+        var svc = new AgenticPipelineService(
+            vertex.Object, db,
+            Options.Create(opts ?? new VertexAiPipelineOptions()),
+            hub.Object,
+            new Mock<ILogger<AgenticPipelineService>>().Object);
+        return (svc, vertex, sent);
+    }
+
+    private static void SetupHappyPath(Mock<IVertexRestClient> vertex)
+    {
+        vertex.Setup(v => v.CreateCachedContentAsync(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("projects/p/locations/us-central1/cachedContents/abc");
+        vertex.Setup(v => v.DeleteCachedContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        vertex.SetupSequence(v => v.ExtractText(It.IsAny<JsonElement>()))
+            .Returns(VisualDna)     // Phase 1
+            .Returns(EventsJson)    // Phase 2
+            .Returns(EventsJson)    // Phase 3 (verifier returns same shape)
+            .Returns(CoachingJson); // Phase 4
+    }
+
+    [Fact]
+    public async Task Should_PersistFullResult_When_PipelineSucceeds()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var videoId = await SeedAsync(db);
+        var (svc, vertex, sent) = CreateService(db, SetupHappyPath);
+
+        await svc.RunPipelineAsync(videoId, CancellationToken.None);
+
+        var result = await db.AiAnalysisResults
+            .Include(a => a.MatchEvents)
+            .Include(a => a.CoachingReport!).ThenInclude(c => c.Strengths)
+            .Include(a => a.CoachingReport!).ThenInclude(c => c.Weaknesses)
+            .Include(a => a.CoachingReport!).ThenInclude(c => c.PrescribedDrills)
+            .FirstAsync(a => a.VideoId == videoId);
+
+        Assert.Equal(VisualDna, result.VisualDna);
+        Assert.Equal(AnalysisPipelineStatus.Complete, result.PipelineStatus);
+        Assert.Equal(2, result.MatchEvents.Count);
+        Assert.Equal(78, result.TechnicalGrade);
+        Assert.Equal("Solid Fundamentals", result.GradeLabel);
+        Assert.False(string.IsNullOrEmpty(result.EliteTip));
+        Assert.NotNull(result.CoachingReport);
+        Assert.Single(result.CoachingReport!.Strengths);
+        Assert.Single(result.CoachingReport!.Weaknesses);
+        Assert.Equal(3, result.CoachingReport!.PrescribedDrills.Count);
+        Assert.Equal(WeaknessSeverity.Major, result.CoachingReport!.Weaknesses.First().Severity);
+
+        // Sequence index preserves model order; enums parsed from strings.
+        var first = result.MatchEvents.OrderBy(e => e.SequenceIndex).First();
+        Assert.Equal(EventActor.Student, first.Actor);
+        Assert.Equal(EventOutcome.Successful, first.Outcome);
+    }
+
+    [Fact]
+    public async Task Should_EmitStatusTransitions_InOrder()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var videoId = await SeedAsync(db);
+        var (svc, _, sent) = CreateService(db, SetupHappyPath);
+
+        await svc.RunPipelineAsync(videoId, CancellationToken.None);
+
+        Assert.Contains("AnalysisStatusChanged:Profiling", sent);
+        Assert.Contains("AnalysisStatusChanged:Logging", sent);
+        Assert.Contains("AnalysisStatusChanged:Verifying", sent);
+        Assert.Contains("AnalysisStatusChanged:Coaching", sent);
+        Assert.Contains("AnalysisStatusChanged:Complete", sent);
+        Assert.Contains(sent, s => s.StartsWith("AnalysisV2Completed"));
+    }
+
+    [Fact]
+    public async Task Should_CreateAndDeleteCache_OnSuccess()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var videoId = await SeedAsync(db);
+        var (svc, vertex, _) = CreateService(db, SetupHappyPath);
+
+        await svc.RunPipelineAsync(videoId, CancellationToken.None);
+
+        vertex.Verify(v => v.CreateCachedContentAsync(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        vertex.Verify(v => v.DeleteCachedContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Should_CompleteViaFallback_When_CacheCreationFails()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var videoId = await SeedAsync(db);
+        var (svc, vertex, _) = CreateService(db, v =>
+        {
+            v.Setup(x => x.CreateCachedContentAsync(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("cache too small"));
+            v.SetupSequence(x => x.ExtractText(It.IsAny<JsonElement>()))
+                .Returns(VisualDna).Returns(EventsJson).Returns(EventsJson).Returns(CoachingJson);
+        });
+
+        await svc.RunPipelineAsync(videoId, CancellationToken.None);
+
+        var result = await db.AiAnalysisResults.Include(a => a.MatchEvents).FirstAsync(a => a.VideoId == videoId);
+        Assert.Equal(AnalysisPipelineStatus.Complete, result.PipelineStatus);
+        Assert.Equal(2, result.MatchEvents.Count);
+        // No cache was created → nothing to delete.
+        vertex.Verify(v => v.DeleteCachedContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Should_MarkFailedAndCleanupCache_When_PhaseThrows()
+    {
+        using var db = InMemoryDbContextFactory.Create();
+        var videoId = await SeedAsync(db);
+        var (svc, vertex, sent) = CreateService(db, v =>
+        {
+            v.Setup(x => x.CreateCachedContentAsync(It.IsAny<object>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync("projects/p/locations/us-central1/cachedContents/abc");
+            v.Setup(x => x.DeleteCachedContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            v.SetupSequence(x => x.ExtractText(It.IsAny<JsonElement>()))
+                .Returns(VisualDna)
+                .Returns("this is not valid json");  // Phase 2 parse fails
+        });
+
+        await Assert.ThrowsAsync<JsonException>(() => svc.RunPipelineAsync(videoId, CancellationToken.None));
+
+        var result = await db.AiAnalysisResults.FirstAsync(a => a.VideoId == videoId);
+        Assert.Equal(AnalysisPipelineStatus.Failed, result.PipelineStatus);
+        Assert.False(string.IsNullOrEmpty(result.PipelineError));
+        Assert.Contains(sent, s => s.StartsWith("AnalysisV2Failed"));
+        // Cache created in Phase 1 must still be cleaned up in finally.
+        vertex.Verify(v => v.DeleteCachedContentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To get started, clone the repository and open the project in Visual Studio 2022.
 - [Docker Desktop](https://www.docker.com/products/docker-desktop)
 - [Node.js](https://nodejs.org/en/)
 - [React](https://reactjs.org/)
-- [.Net 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- [.Net 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) (outdated! should be 10)
 
 ### .env Configuration
 

--- a/SharedEntities/Data/DatabaseContext.cs
+++ b/SharedEntities/Data/DatabaseContext.cs
@@ -38,6 +38,12 @@ public class MyDatabaseContext : IdentityDbContext<AppUserEntity>
     public virtual DbSet<WeaknessCategory> WeaknessCategories { get; set; }
     public virtual DbSet<AnalysisWeakness> AnalysisWeaknesses { get; set; }
 
+    public virtual DbSet<MatchEvent> MatchEvents { get; set; }
+    public virtual DbSet<CoachingReport> CoachingReports { get; set; }
+    public virtual DbSet<CoachingStrength> CoachingStrengths { get; set; }
+    public virtual DbSet<CoachingWeakness> CoachingWeaknesses { get; set; }
+    public virtual DbSet<PrescribedDrill> PrescribedDrills { get; set; }
+
     public virtual DbSet<Techniques> Techniques { get; set; }
     public virtual DbSet<PointScoringTechnique> PointScoringTechniques { get; set; }
 
@@ -133,5 +139,40 @@ public class MyDatabaseContext : IdentityDbContext<AppUserEntity>
         builder.Entity<TrainingSession>()
             .Property(ts => ts.EditedFighterPairsJson)
             .HasColumnType("jsonb");
+
+        // ── Agentic (v2) pipeline relationships ──
+        // 1:1 AiAnalysisResult ↔ CoachingReport; deleting the analysis cascades the report and its children.
+        builder.Entity<AiAnalysisResult>()
+            .HasOne(a => a.CoachingReport)
+            .WithOne(c => c.AiAnalysisResult)
+            .HasForeignKey<CoachingReport>(c => c.AiAnalysisResultId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<MatchEvent>()
+            .HasOne(e => e.AiAnalysisResult)
+            .WithMany(a => a.MatchEvents)
+            .HasForeignKey(e => e.AiAnalysisResultId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<MatchEvent>()
+            .HasIndex(e => new { e.AiAnalysisResultId, e.SequenceIndex });
+
+        builder.Entity<CoachingStrength>()
+            .HasOne(s => s.CoachingReport)
+            .WithMany(c => c.Strengths)
+            .HasForeignKey(s => s.CoachingReportId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<CoachingWeakness>()
+            .HasOne(w => w.CoachingReport)
+            .WithMany(c => c.Weaknesses)
+            .HasForeignKey(w => w.CoachingReportId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<PrescribedDrill>()
+            .HasOne(d => d.CoachingReport)
+            .WithMany(c => c.PrescribedDrills)
+            .HasForeignKey(d => d.CoachingReportId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/SharedEntities/Migrations/20260604091803_AddAgenticPipelineEntities.Designer.cs
+++ b/SharedEntities/Migrations/20260604091803_AddAgenticPipelineEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SharedEntities.Data;
@@ -11,9 +12,11 @@ using SharedEntities.Data;
 namespace SharedEntities.Migrations
 {
     [DbContext(typeof(MyDatabaseContext))]
-    partial class MyDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20260604091803_AddAgenticPipelineEntities")]
+    partial class AddAgenticPipelineEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SharedEntities/Migrations/20260604091803_AddAgenticPipelineEntities.cs
+++ b/SharedEntities/Migrations/20260604091803_AddAgenticPipelineEntities.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace SharedEntities.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAgenticPipelineEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "app_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "now() at time zone 'utc'",
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValue: new DateTime(2025, 6, 3, 13, 14, 28, 105, DateTimeKind.Utc).AddTicks(8020));
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "app_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "now() at time zone 'utc'",
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValue: new DateTime(2025, 6, 3, 13, 14, 28, 105, DateTimeKind.Utc).AddTicks(7140));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContextCacheName",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EliteTip",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GradeLabel",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MatchSummary",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PipelineError",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PipelineStatus",
+                table: "AiAnalysisResults",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TechnicalGrade",
+                table: "AiAnalysisResults",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "VisualDna",
+                table: "AiAnalysisResults",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CoachingReports",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AiAnalysisResultId = table.Column<int>(type: "integer", nullable: false),
+                    MatchSummary = table.Column<string>(type: "text", nullable: false),
+                    TechnicalGrade = table.Column<int>(type: "integer", nullable: false),
+                    GradeLabel = table.Column<string>(type: "text", nullable: true),
+                    EliteTip = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CoachingReports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CoachingReports_AiAnalysisResults_AiAnalysisResultId",
+                        column: x => x.AiAnalysisResultId,
+                        principalTable: "AiAnalysisResults",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MatchEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AiAnalysisResultId = table.Column<int>(type: "integer", nullable: false),
+                    StartTimestampMs = table.Column<int>(type: "integer", nullable: false),
+                    EndTimestampMs = table.Column<int>(type: "integer", nullable: false),
+                    Actor = table.Column<int>(type: "integer", nullable: false),
+                    TechniqueCategory = table.Column<string>(type: "text", nullable: false),
+                    TechniqueName = table.Column<string>(type: "text", nullable: true),
+                    PositionBefore = table.Column<string>(type: "text", nullable: true),
+                    PositionAfter = table.Column<string>(type: "text", nullable: true),
+                    Outcome = table.Column<int>(type: "integer", nullable: false),
+                    GuardType = table.Column<string>(type: "text", nullable: true),
+                    SubmissionType = table.Column<string>(type: "text", nullable: true),
+                    ActionsDescription = table.Column<string>(type: "text", nullable: true),
+                    Confidence = table.Column<double>(type: "double precision", nullable: false),
+                    SequenceIndex = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MatchEvents", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MatchEvents_AiAnalysisResults_AiAnalysisResultId",
+                        column: x => x.AiAnalysisResultId,
+                        principalTable: "AiAnalysisResults",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CoachingStrengths",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CoachingReportId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Explanation = table.Column<string>(type: "text", nullable: true),
+                    TimestampStartMs = table.Column<int>(type: "integer", nullable: true),
+                    TimestampEndMs = table.Column<int>(type: "integer", nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CoachingStrengths", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CoachingStrengths_CoachingReports_CoachingReportId",
+                        column: x => x.CoachingReportId,
+                        principalTable: "CoachingReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CoachingWeaknesses",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CoachingReportId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Explanation = table.Column<string>(type: "text", nullable: true),
+                    TimestampStartMs = table.Column<int>(type: "integer", nullable: true),
+                    TimestampEndMs = table.Column<int>(type: "integer", nullable: true),
+                    Severity = table.Column<int>(type: "integer", nullable: false),
+                    ScoringImpact = table.Column<string>(type: "text", nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CoachingWeaknesses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CoachingWeaknesses_CoachingReports_CoachingReportId",
+                        column: x => x.CoachingReportId,
+                        principalTable: "CoachingReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PrescribedDrills",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CoachingReportId = table.Column<int>(type: "integer", nullable: false),
+                    DrillName = table.Column<string>(type: "text", nullable: false),
+                    Instructions = table.Column<string>(type: "text", nullable: true),
+                    Goal = table.Column<string>(type: "text", nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PrescribedDrills", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PrescribedDrills_CoachingReports_CoachingReportId",
+                        column: x => x.CoachingReportId,
+                        principalTable: "CoachingReports",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoachingReports_AiAnalysisResultId",
+                table: "CoachingReports",
+                column: "AiAnalysisResultId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoachingStrengths_CoachingReportId",
+                table: "CoachingStrengths",
+                column: "CoachingReportId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CoachingWeaknesses_CoachingReportId",
+                table: "CoachingWeaknesses",
+                column: "CoachingReportId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchEvents_AiAnalysisResultId_SequenceIndex",
+                table: "MatchEvents",
+                columns: new[] { "AiAnalysisResultId", "SequenceIndex" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PrescribedDrills_CoachingReportId",
+                table: "PrescribedDrills",
+                column: "CoachingReportId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CoachingStrengths");
+
+            migrationBuilder.DropTable(
+                name: "CoachingWeaknesses");
+
+            migrationBuilder.DropTable(
+                name: "MatchEvents");
+
+            migrationBuilder.DropTable(
+                name: "PrescribedDrills");
+
+            migrationBuilder.DropTable(
+                name: "CoachingReports");
+
+            migrationBuilder.DropColumn(
+                name: "ContextCacheName",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "EliteTip",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "GradeLabel",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "MatchSummary",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "PipelineError",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "PipelineStatus",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "TechnicalGrade",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.DropColumn(
+                name: "VisualDna",
+                table: "AiAnalysisResults");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "UpdatedAt",
+                table: "app_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(2025, 6, 3, 13, 14, 28, 105, DateTimeKind.Utc).AddTicks(8020),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "now() at time zone 'utc'");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "CreatedAt",
+                table: "app_users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(2025, 6, 3, 13, 14, 28, 105, DateTimeKind.Utc).AddTicks(7140),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "now() at time zone 'utc'");
+        }
+    }
+}

--- a/SharedEntities/Models/Feedbacks.cs
+++ b/SharedEntities/Models/Feedbacks.cs
@@ -70,6 +70,29 @@ namespace SharedEntities.Models
         public DateTime? LastUpdatedAt { get; set; }
 
         public string? UpdatedBy { get; set; } //AppUser.Id
+
+        // ── Agentic (v2) pipeline fields — nullable so legacy single-shot rows are unaffected ──
+
+        /// <summary>Phase 1 (Auto-Profiler) output: immutable "Visual DNA" of the student athlete.</summary>
+        public string? VisualDna { get; set; }
+
+        /// <summary>Phase 4 (Head Coach) overall technical grade, 0–100. Mirrored from CoachingReport for list reads.</summary>
+        public int? TechnicalGrade { get; set; }
+        public string? GradeLabel { get; set; }
+        public string? EliteTip { get; set; }
+        public string? MatchSummary { get; set; }
+
+        /// <summary>Current state of the multi-step pipeline (NotStarted for legacy rows).</summary>
+        public AnalysisPipelineStatus PipelineStatus { get; set; } = AnalysisPipelineStatus.NotStarted;
+
+        /// <summary>Populated when the pipeline fails.</summary>
+        public string? PipelineError { get; set; }
+
+        /// <summary>Active Vertex context-cache resource name during a run (for finally-cleanup across retries).</summary>
+        public string? ContextCacheName { get; set; }
+
+        public virtual ICollection<MatchEvent> MatchEvents { get; set; } = [];
+        public virtual CoachingReport? CoachingReport { get; set; }
     }
 
     public class WeaknessCategory

--- a/SharedEntities/Models/MatchAnalysis.cs
+++ b/SharedEntities/Models/MatchAnalysis.cs
@@ -1,0 +1,162 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SharedEntities.Models
+{
+    /// <summary>
+    /// Status of the multi-step (agentic) video-analysis pipeline. Mirrors the PRD status
+    /// transitions: NotStarted → Profiling → Logging → Verifying → Coaching → Complete | Failed.
+    /// </summary>
+    public enum AnalysisPipelineStatus
+    {
+        NotStarted = 0,
+        Profiling = 1,
+        Logging = 2,
+        Verifying = 3,
+        Coaching = 4,
+        Complete = 5,
+        Failed = 6,
+    }
+
+    public enum EventActor
+    {
+        Student = 0,
+        Opponent = 1,
+    }
+
+    public enum EventOutcome
+    {
+        Successful = 0,
+        Failed = 1,
+        Partial = 2,
+        Countered = 3,
+        InProgress = 4,
+    }
+
+    public enum WeaknessSeverity
+    {
+        Critical = 0,
+        Major = 1,
+        Minor = 2,
+    }
+
+    /// <summary>
+    /// A single timestamped exchange in a match, produced by the Event Logger (Phase 2) and
+    /// corrected by the Event Verifier (Phase 3). Timestamps are absolute milliseconds from the
+    /// start of the video (distinct from the legacy <see cref="VideoSegmentFeedback"/> TimeSpan path).
+    /// </summary>
+    public class MatchEvent
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int AiAnalysisResultId { get; set; }
+        [ForeignKey(nameof(AiAnalysisResultId))]
+        public virtual AiAnalysisResult AiAnalysisResult { get; set; }
+
+        public int StartTimestampMs { get; set; }
+        public int EndTimestampMs { get; set; }
+
+        public EventActor Actor { get; set; }
+
+        /// <summary>One of the 12 technique categories. Stored as string for taxonomy evolution.</summary>
+        public required string TechniqueCategory { get; set; }
+
+        /// <summary>Free-text specific technique name (e.g. "Double Leg", "Armbar from Guard").</summary>
+        public string? TechniqueName { get; set; }
+
+        /// <summary>One of the 13 position values. Stored as string.</summary>
+        public string? PositionBefore { get; set; }
+        public string? PositionAfter { get; set; }
+
+        public EventOutcome Outcome { get; set; }
+
+        public string? GuardType { get; set; }
+        public string? SubmissionType { get; set; }
+
+        public string? ActionsDescription { get; set; }
+
+        /// <summary>VLM self-assessed confidence 0.0–1.0 (min of actor/technique/position certainty).</summary>
+        public double Confidence { get; set; }
+
+        /// <summary>Preserves the model's event ordering for stable reads.</summary>
+        public int SequenceIndex { get; set; }
+    }
+
+    /// <summary>
+    /// The Head Coach (Phase 4) synthesis: one per analysis. Strengths/weaknesses/drills live in
+    /// child tables; grade/label/tip/summary are mirrored onto <see cref="AiAnalysisResult"/> for
+    /// quick list reads but owned here.
+    /// </summary>
+    public class CoachingReport
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int AiAnalysisResultId { get; set; }
+        [ForeignKey(nameof(AiAnalysisResultId))]
+        public virtual AiAnalysisResult AiAnalysisResult { get; set; }
+
+        public required string MatchSummary { get; set; }
+        public int TechnicalGrade { get; set; }
+        public string? GradeLabel { get; set; }
+        public string? EliteTip { get; set; }
+
+        public virtual ICollection<CoachingStrength> Strengths { get; set; } = [];
+        public virtual ICollection<CoachingWeakness> Weaknesses { get; set; } = [];
+        public virtual ICollection<PrescribedDrill> PrescribedDrills { get; set; } = [];
+    }
+
+    public class CoachingStrength
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int CoachingReportId { get; set; }
+        [ForeignKey(nameof(CoachingReportId))]
+        public virtual CoachingReport CoachingReport { get; set; }
+
+        public required string Title { get; set; }
+        public string? Explanation { get; set; }
+        public int? TimestampStartMs { get; set; }
+        public int? TimestampEndMs { get; set; }
+        public int SortOrder { get; set; }
+    }
+
+    public class CoachingWeakness
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int CoachingReportId { get; set; }
+        [ForeignKey(nameof(CoachingReportId))]
+        public virtual CoachingReport CoachingReport { get; set; }
+
+        public required string Title { get; set; }
+        public string? Explanation { get; set; }
+        public int? TimestampStartMs { get; set; }
+        public int? TimestampEndMs { get; set; }
+        public WeaknessSeverity Severity { get; set; }
+        public string? ScoringImpact { get; set; }
+        public int SortOrder { get; set; }
+    }
+
+    /// <summary>
+    /// A drill prescribed by the Head Coach. Intentionally distinct from <see cref="Drills"/>
+    /// (which requires a Technique FK and carries Focus/Duration); this shape is drill/goal/instructions.
+    /// </summary>
+    public class PrescribedDrill
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public int CoachingReportId { get; set; }
+        [ForeignKey(nameof(CoachingReportId))]
+        public virtual CoachingReport CoachingReport { get; set; }
+
+        public required string DrillName { get; set; }
+        public string? Instructions { get; set; }
+        public string? Goal { get; set; }
+        public int SortOrder { get; set; }
+    }
+}

--- a/VideoAnalysis.Server/Configuration/VertexAiPipelineOptions.cs
+++ b/VideoAnalysis.Server/Configuration/VertexAiPipelineOptions.cs
@@ -1,0 +1,52 @@
+namespace VideoAnalysis.Server.Configuration
+{
+    /// <summary>
+    /// Strongly-typed options for the agentic (multi-step) Vertex AI video-analysis pipeline.
+    /// Bound from the <c>VertexAi:Pipeline</c> configuration section. Environment overrides use
+    /// the standard ASP.NET nesting delimiter, e.g. <c>VertexAi__Pipeline__Location</c>.
+    /// </summary>
+    public class VertexAiPipelineOptions
+    {
+        public const string SectionName = "VertexAi:Pipeline";
+
+        /// <summary>Feature flag. When false, callers fall back to the single-shot v1 path.</summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Vertex location used for the pipeline. The proven MyCoach mobile pipeline runs context
+        /// caching on the GLOBAL endpoint (https://aiplatform.googleapis.com + locations/global/cachedContents),
+        /// validated with real uploads — so "global" is the default and matches the single-shot path.
+        /// </summary>
+        public string Location { get; set; } = "global";
+
+        /// <summary>Context-cache TTL (minutes). Must exceed expected total pipeline runtime.</summary>
+        public int ContextCacheTtlMinutes { get; set; } = 30;
+
+        /// <summary>Events with confidence below this are flagged for review in the UI.</summary>
+        public double ConfidenceThresholdForReview { get; set; } = 0.7;
+
+        /// <summary>Caps concurrent pipeline jobs (dedicated Hangfire queue worker count).</summary>
+        public int MaxConcurrentJobs { get; set; } = 2;
+
+        public PhaseModelOptions Profiler { get; set; } = new() { Fps = 1, Temperature = 0.1f, MaxOutputTokens = 1024, ThinkingBudget = 8192 };
+        public PhaseModelOptions EventLogger { get; set; } = new() { Fps = 4, Temperature = 0.2f, MaxOutputTokens = 65535, ThinkingBudget = 16384 };
+        public PhaseModelOptions Verifier { get; set; } = new() { Fps = 0, Temperature = 0.1f, MaxOutputTokens = 65535, ThinkingBudget = 4096 };
+        public PhaseModelOptions HeadCoach { get; set; } = new() { Fps = 0, Temperature = 0.4f, MaxOutputTokens = 8192, ThinkingBudget = 16384 };
+    }
+
+    /// <summary>Per-phase Vertex model + generation settings.</summary>
+    public class PhaseModelOptions
+    {
+        public string ModelId { get; set; } = "gemini-3.1-pro-preview";
+
+        /// <summary>Frames-per-second for video sampling. 0 = phase does not do frame-by-frame work.</summary>
+        public int Fps { get; set; }
+
+        public float Temperature { get; set; }
+
+        public int MaxOutputTokens { get; set; }
+
+        /// <summary>Thinking-token budget. 0 disables thinking for the phase.</summary>
+        public int ThinkingBudget { get; set; }
+    }
+}

--- a/VideoAnalysis.Server/Controllers/GeminiController.cs
+++ b/VideoAnalysis.Server/Controllers/GeminiController.cs
@@ -4,8 +4,11 @@ using Hangfire;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using SharedEntities.Data;
 using SharedEntities.Models;
+using VideoAnalysis.Server.Configuration;
+using VideoAnalysis.Server.Domain.AIServices;
 using VideoAnalysis.Server.Domain.GeminiService;
 using VideoAnalysis.Server.Helpers;
 using VideoAnalysis.Server.Models.Dtos;
@@ -19,12 +22,95 @@ namespace VideoAnalysis.Server.Controllers
         private readonly IGeminiVisionService _geminiService;
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<GeminiController> _logger;
+        private readonly VertexAiPipelineOptions _pipelineOptions;
 
-        public GeminiController(IGeminiVisionService geminiService, IServiceProvider serviceProvider, ILogger<GeminiController> logger)
+        public GeminiController(IGeminiVisionService geminiService, IServiceProvider serviceProvider, ILogger<GeminiController> logger, IOptions<VertexAiPipelineOptions> pipelineOptions)
         {
             _geminiService = geminiService;
             _serviceProvider = serviceProvider;
             _logger = logger;
+            _pipelineOptions = pipelineOptions.Value;
+        }
+
+        // ── Agentic (v2) pipeline ─────────────────────────────────────────────
+
+        [HttpPost("analyze-v2/{videoId}")]
+        [Authorize]
+        public async Task<IActionResult> AnalyzeVideoV2Async(int videoId)
+        {
+            if (!_pipelineOptions.Enabled)
+                return BadRequest("The agentic analysis pipeline is disabled.");
+
+            using var scope = _serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<MyDatabaseContext>();
+            if (!await dbContext.Videos.AnyAsync(v => v.Id == videoId))
+                return BadRequest("Invalid VideoId.");
+
+            BackgroundJob.Enqueue<AgenticAnalysisBackgroundJobService>(
+                job => job.ProcessAgenticAnalysisAsync(videoId));
+
+            return Accepted(new { Message = "Agentic video analysis is processing", VideoId = videoId });
+        }
+
+        [HttpGet("{videoId}/analysis-v2")]
+        [Authorize]
+        public async Task<ActionResult<AnalysisV2Dto>> GetVideoAnalysisV2(int videoId)
+        {
+            try
+            {
+                var readService = _serviceProvider.GetRequiredService<AgenticAnalysisReadService>();
+                return Ok(await readService.GetAnalysisV2DtoByVideoId(videoId));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading v2 analysis for videoId {VideoId}", videoId);
+                return StatusCode(500, new { error = "An unexpected error occurred" });
+            }
+        }
+
+        [HttpPatch("{videoId}/analysis-v2")]
+        [Authorize]
+        public async Task<ActionResult<AnalysisV2Dto>> UpdateAnalysisV2Async(int videoId, [FromBody] AnalysisV2Dto dto)
+        {
+            if (dto == null)
+                return BadRequest(new { error = "Request body cannot be null" });
+
+            try
+            {
+                var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                var writeService = _serviceProvider.GetRequiredService<AgenticAnalysisWriteService>();
+                var updated = await writeService.SaveAnalysisV2(videoId, dto, userId);
+                return Ok(updated);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return NotFound(new { error = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error saving v2 analysis for videoId {VideoId}", videoId);
+                return StatusCode(500, new { error = "An unexpected error occurred" });
+            }
+        }
+
+        [HttpGet("{videoId}/status")]
+        [Authorize]
+        public async Task<ActionResult<AnalysisStatusDto>> GetAnalysisStatus(int videoId)
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<MyDatabaseContext>();
+            var result = await dbContext.AiAnalysisResults
+                .AsNoTracking()
+                .FirstOrDefaultAsync(a => a.VideoId == videoId);
+
+            if (result == null)
+                return Ok(new AnalysisStatusDto { Status = AnalysisPipelineStatus.NotStarted.ToString() });
+
+            return Ok(new AnalysisStatusDto { Status = result.PipelineStatus.ToString(), Error = result.PipelineError });
         }
 
         [HttpPost("analyze/{videoId}")]

--- a/VideoAnalysis.Server/Domain/AIServices/AgenticAnalysisReadService.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/AgenticAnalysisReadService.cs
@@ -1,0 +1,101 @@
+using Microsoft.EntityFrameworkCore;
+using SharedEntities.Data;
+using SharedEntities.Models;
+using VideoAnalysis.Server.Models.Dtos;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    /// <summary>Reads agentic (v2) analysis results and maps them to the frontend DTO.</summary>
+    public class AgenticAnalysisReadService
+    {
+        private readonly MyDatabaseContext _context;
+
+        public AgenticAnalysisReadService(MyDatabaseContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Returns the v2 analysis for a video. Throws <see cref="InvalidOperationException"/> when no
+        /// v2 analysis exists (the controller maps this to 404 so the frontend falls back to legacy).
+        /// </summary>
+        public async Task<AnalysisV2Dto> GetAnalysisV2DtoByVideoId(int videoId)
+        {
+            var result = await _context.AiAnalysisResults
+                .AsSplitQuery()
+                .Include(a => a.MatchEvents)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.Strengths)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.Weaknesses)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.PrescribedDrills)
+                .FirstOrDefaultAsync(a => a.VideoId == videoId);
+
+            // Treat "never ran the v2 pipeline" as not-found so the page can fall back to legacy.
+            if (result == null || (result.PipelineStatus == AnalysisPipelineStatus.NotStarted && result.CoachingReport == null && result.MatchEvents.Count == 0))
+            {
+                throw new InvalidOperationException($"No v2 analysis found for video {videoId}.");
+            }
+
+            return MapToDto(result);
+        }
+
+        public static AnalysisV2Dto MapToDto(AiAnalysisResult result) => new()
+        {
+            Id = result.Id,
+            VideoId = result.VideoId,
+            VisualDna = result.VisualDna,
+            PipelineStatus = result.PipelineStatus.ToString(),
+            TechnicalGrade = result.TechnicalGrade,
+            GradeLabel = result.GradeLabel,
+            EliteTip = result.EliteTip,
+            MatchSummary = result.MatchSummary,
+            MatchEvents = result.MatchEvents
+                .OrderBy(e => e.SequenceIndex)
+                .Select(e => new MatchEventDto
+                {
+                    Id = e.Id,
+                    StartTimestampMs = e.StartTimestampMs,
+                    EndTimestampMs = e.EndTimestampMs,
+                    Actor = e.Actor.ToString(),
+                    TechniqueCategory = e.TechniqueCategory,
+                    TechniqueName = e.TechniqueName,
+                    PositionBefore = e.PositionBefore,
+                    PositionAfter = e.PositionAfter,
+                    Outcome = e.Outcome.ToString(),
+                    GuardType = e.GuardType,
+                    SubmissionType = e.SubmissionType,
+                    ActionsDescription = e.ActionsDescription,
+                    Confidence = e.Confidence,
+                })
+                .ToList(),
+            CoachingReport = result.CoachingReport == null ? null : new CoachingReportDto
+            {
+                Id = result.CoachingReport.Id,
+                MatchSummary = result.CoachingReport.MatchSummary,
+                TechnicalGrade = result.CoachingReport.TechnicalGrade,
+                GradeLabel = result.CoachingReport.GradeLabel,
+                EliteTip = result.CoachingReport.EliteTip,
+                KeyStrengths = result.CoachingReport.Strengths
+                    .OrderBy(s => s.SortOrder)
+                    .Select(s => new CoachingStrengthDto
+                    {
+                        Id = s.Id, Title = s.Title, Explanation = s.Explanation,
+                        TimestampStartMs = s.TimestampStartMs, TimestampEndMs = s.TimestampEndMs,
+                    }).ToList(),
+                CriticalWeaknesses = result.CoachingReport.Weaknesses
+                    .OrderBy(w => w.SortOrder)
+                    .Select(w => new CoachingWeaknessDto
+                    {
+                        Id = w.Id, Title = w.Title, Explanation = w.Explanation,
+                        TimestampStartMs = w.TimestampStartMs, TimestampEndMs = w.TimestampEndMs,
+                        Severity = w.Severity.ToString(), ScoringImpact = w.ScoringImpact,
+                    }).ToList(),
+                PrescribedDrills = result.CoachingReport.PrescribedDrills
+                    .OrderBy(d => d.SortOrder)
+                    .Select(d => new PrescribedDrillDto
+                    {
+                        Id = d.Id, DrillName = d.DrillName, Instructions = d.Instructions, Goal = d.Goal,
+                    }).ToList(),
+            },
+        };
+    }
+}

--- a/VideoAnalysis.Server/Domain/AIServices/AgenticAnalysisWriteService.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/AgenticAnalysisWriteService.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using SharedEntities.Data;
+using SharedEntities.Models;
+using VideoAnalysis.Server.Models.Dtos;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    /// <summary>
+    /// Persists user edits to a v2 analysis (full editable parity). Match events and coaching-report
+    /// children are reconciled wholesale from the incoming DTO — whatever the client sends becomes the
+    /// new truth, which cleanly handles add/edit/delete in one call.
+    /// </summary>
+    public class AgenticAnalysisWriteService
+    {
+        private readonly MyDatabaseContext _context;
+
+        public AgenticAnalysisWriteService(MyDatabaseContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<AnalysisV2Dto> SaveAnalysisV2(int videoId, AnalysisV2Dto dto, string? userId)
+        {
+            var result = await _context.AiAnalysisResults
+                .Include(a => a.MatchEvents)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.Strengths)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.Weaknesses)
+                .Include(a => a.CoachingReport!).ThenInclude(c => c.PrescribedDrills)
+                .FirstOrDefaultAsync(a => a.VideoId == videoId)
+                ?? throw new InvalidOperationException($"No analysis found for video {videoId}.");
+
+            // ── Headline scalar fields ──
+            if (dto.VisualDna != null) result.VisualDna = dto.VisualDna;
+            result.LastUpdatedAt = DateTime.UtcNow;
+            result.UpdatedBy = userId ?? result.UpdatedBy;
+
+            // ── Match events: wholesale replace, ordered ──
+            if (dto.MatchEvents != null)
+            {
+                _context.MatchEvents.RemoveRange(result.MatchEvents);
+                int i = 0;
+                foreach (var e in dto.MatchEvents)
+                {
+                    result.MatchEvents.Add(new MatchEvent
+                    {
+                        AiAnalysisResultId = result.Id,
+                        StartTimestampMs = e.StartTimestampMs,
+                        EndTimestampMs = e.EndTimestampMs,
+                        Actor = ParseEnum(e.Actor, EventActor.Student),
+                        TechniqueCategory = string.IsNullOrWhiteSpace(e.TechniqueCategory) ? "Transition" : e.TechniqueCategory,
+                        TechniqueName = e.TechniqueName,
+                        PositionBefore = e.PositionBefore,
+                        PositionAfter = e.PositionAfter,
+                        Outcome = ParseEnum(e.Outcome, EventOutcome.InProgress),
+                        GuardType = e.GuardType,
+                        SubmissionType = e.SubmissionType,
+                        ActionsDescription = e.ActionsDescription,
+                        Confidence = e.Confidence,
+                        SequenceIndex = i++,
+                    });
+                }
+            }
+
+            // ── Coaching report: replace children, update scalars ──
+            if (dto.CoachingReport != null)
+            {
+                if (result.CoachingReport != null) _context.CoachingReports.Remove(result.CoachingReport);
+
+                var cr = dto.CoachingReport;
+                var report = new CoachingReport
+                {
+                    AiAnalysisResultId = result.Id,
+                    MatchSummary = cr.MatchSummary ?? string.Empty,
+                    TechnicalGrade = Math.Clamp(cr.TechnicalGrade, 0, 100),
+                    GradeLabel = cr.GradeLabel,
+                    EliteTip = cr.EliteTip,
+                    Strengths = (cr.KeyStrengths ?? []).Select((s, idx) => new CoachingStrength
+                    {
+                        Title = s.Title, Explanation = s.Explanation,
+                        TimestampStartMs = s.TimestampStartMs, TimestampEndMs = s.TimestampEndMs, SortOrder = idx,
+                    }).ToList(),
+                    Weaknesses = (cr.CriticalWeaknesses ?? []).Select((w, idx) => new CoachingWeakness
+                    {
+                        Title = w.Title, Explanation = w.Explanation,
+                        TimestampStartMs = w.TimestampStartMs, TimestampEndMs = w.TimestampEndMs,
+                        Severity = ParseEnum(w.Severity, WeaknessSeverity.Major), ScoringImpact = w.ScoringImpact, SortOrder = idx,
+                    }).ToList(),
+                    PrescribedDrills = (cr.PrescribedDrills ?? []).Select((d, idx) => new PrescribedDrill
+                    {
+                        DrillName = d.DrillName, Instructions = d.Instructions, Goal = d.Goal, SortOrder = idx,
+                    }).ToList(),
+                };
+                result.CoachingReport = report;
+
+                // keep mirrored headline fields in sync
+                result.MatchSummary = report.MatchSummary;
+                result.TechnicalGrade = report.TechnicalGrade;
+                result.GradeLabel = report.GradeLabel;
+                result.EliteTip = report.EliteTip;
+            }
+
+            await _context.SaveChangesAsync();
+
+            // Re-read for a clean, ordered DTO with fresh Ids.
+            return await new AgenticAnalysisReadService(_context).GetAnalysisV2DtoByVideoId(videoId);
+        }
+
+        private static TEnum ParseEnum<TEnum>(string? value, TEnum fallback) where TEnum : struct =>
+            Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed) ? parsed : fallback;
+    }
+}

--- a/VideoAnalysis.Server/Domain/AIServices/AgenticPipelineService.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/AgenticPipelineService.cs
@@ -1,0 +1,431 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.StaticFiles;
+using SharedEntities.Data;
+using SharedEntities.Models;
+using VideoAnalysis.Server.Configuration;
+using VideoAnalysis.Server.Domain.YoutubeSharingService;
+using VideoAnalysis.Server.Models.Dtos;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    public interface IAgenticPipelineService
+    {
+        /// <summary>Runs the full 4-phase agentic analysis pipeline for an uploaded video.</summary>
+        Task RunPipelineAsync(int videoId, CancellationToken ct);
+    }
+
+    /// <summary>
+    /// Orchestrates the 4-phase agentic VLM pipeline (Auto-Profiler → Event Logger → Event Verifier
+    /// → Head Coach), sharing a single Vertex context cache of the video across phases when possible.
+    /// Emits per-phase status over SignalR and persists results to the v2 entity tables.
+    /// </summary>
+    public class AgenticPipelineService : IAgenticPipelineService
+    {
+        private readonly IVertexRestClient _vertex;
+        private readonly MyDatabaseContext _context;
+        private readonly VertexAiPipelineOptions _options;
+        private readonly IHubContext<VideoAnalysisHub> _hub;
+        private readonly ILogger<AgenticPipelineService> _logger;
+
+        private static readonly JsonSerializerOptions ParseOptions = new() { PropertyNameCaseInsensitive = true };
+
+        public AgenticPipelineService(
+            IVertexRestClient vertex,
+            MyDatabaseContext context,
+            IOptions<VertexAiPipelineOptions> options,
+            IHubContext<VideoAnalysisHub> hub,
+            ILogger<AgenticPipelineService> logger)
+        {
+            _vertex = vertex;
+            _context = context;
+            _options = options.Value;
+            _hub = hub;
+            _logger = logger;
+        }
+
+        public async Task RunPipelineAsync(int videoId, CancellationToken ct)
+        {
+            var video = await _context.Videos.FirstOrDefaultAsync(v => v.Id == videoId, ct)
+                ?? throw new InvalidOperationException($"Video {videoId} not found.");
+            var appUser = await _context.Users.Include(u => u.Fighter).FirstAsync(u => u.Id == video.UserId, ct);
+
+            var fileUri = video.FilePath ?? throw new InvalidOperationException($"Video {videoId} has no FilePath.");
+            var mimeType = DetermineMimeType(fileUri);
+            var studentIdentifier = video.StudentIdentifier ?? "the most active athlete in the video";
+
+            var result = await GetOrCreateResultAsync(videoId, video.UserId, ct);
+
+            string? cacheName = null;
+            try
+            {
+                // ── Phase 1: Auto-Profiler (+ context cache creation) ─────────
+                await UpdateStatusAsync(result, AnalysisPipelineStatus.Profiling, videoId, ct);
+                cacheName = await TryCreateCacheAsync(fileUri, mimeType, videoId, ct);
+                result.ContextCacheName = cacheName;
+                await _context.SaveChangesAsync(ct);
+
+                var visualDna = await RunProfilerAsync(cacheName, fileUri, mimeType, studentIdentifier, ct);
+                result.VisualDna = visualDna;
+                await _context.SaveChangesAsync(ct);
+
+                // ── Phase 2: Event Logger ─────────────────────────────────────
+                await UpdateStatusAsync(result, AnalysisPipelineStatus.Logging, videoId, ct);
+                var rawEvents = await RunEventLoggerAsync(cacheName, fileUri, mimeType, visualDna, ct);
+
+                // ── Phase 3: Event Verifier ───────────────────────────────────
+                await UpdateStatusAsync(result, AnalysisPipelineStatus.Verifying, videoId, ct);
+                var verifiedEvents = await RunVerifierAsync(cacheName, fileUri, mimeType, rawEvents, visualDna, ct);
+
+                PersistMatchEvents(result, verifiedEvents);
+                result.AnalysisJson = JsonSerializer.Serialize(new VertexEventsResponse { Events = verifiedEvents });
+                await _context.SaveChangesAsync(ct);
+
+                // ── Phase 4: Head Coach ───────────────────────────────────────
+                await UpdateStatusAsync(result, AnalysisPipelineStatus.Coaching, videoId, ct);
+                var report = await RunHeadCoachAsync(cacheName, fileUri, mimeType, verifiedEvents, visualDna, appUser.Fighter, ct);
+
+                PersistCoachingReport(result, report);
+                await UpdateStatusAsync(result, AnalysisPipelineStatus.Complete, videoId, ct);
+                await _hub.Clients.All.SendAsync("AnalysisV2Completed", videoId, ct);
+                _logger.LogInformation("Agentic pipeline complete for video {VideoId}.", videoId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Agentic pipeline failed for video {VideoId}.", videoId);
+                result.PipelineStatus = AnalysisPipelineStatus.Failed;
+                result.PipelineError = ex.Message;
+                await _context.SaveChangesAsync(CancellationToken.None);
+                await _hub.Clients.All.SendAsync("AnalysisV2Failed", videoId, ex.Message, CancellationToken.None);
+                throw;
+            }
+            finally
+            {
+                if (cacheName != null)
+                {
+                    try { await _vertex.DeleteCachedContentAsync(cacheName, _options.Location, CancellationToken.None); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Context cache cleanup failed for {CacheName}", cacheName); }
+                    result.ContextCacheName = null;
+                    await _context.SaveChangesAsync(CancellationToken.None);
+                }
+            }
+        }
+
+        // ── Persistence helpers ──────────────────────────────────────────────
+
+        private async Task<AiAnalysisResult> GetOrCreateResultAsync(int videoId, string userId, CancellationToken ct)
+        {
+            var existing = await _context.AiAnalysisResults.FirstOrDefaultAsync(a => a.VideoId == videoId, ct);
+            if (existing != null) return existing;
+
+            var created = new AiAnalysisResult
+            {
+                VideoId = videoId,
+                AnalysisJson = "{}",
+                Strengths = "[]",
+                AreasForImprovement = "[]",
+                Techniques = [],
+                Drills = [],
+                GeneratedAt = DateTime.UtcNow,
+                UpdatedBy = userId,
+                PipelineStatus = AnalysisPipelineStatus.NotStarted,
+            };
+            _context.AiAnalysisResults.Add(created);
+            await _context.SaveChangesAsync(ct);
+            return created;
+        }
+
+        private async Task UpdateStatusAsync(AiAnalysisResult result, AnalysisPipelineStatus status, int videoId, CancellationToken ct)
+        {
+            result.PipelineStatus = status;
+            result.LastUpdatedAt = DateTime.UtcNow;
+            await _context.SaveChangesAsync(ct);
+            await _hub.Clients.All.SendAsync("AnalysisStatusChanged", videoId, status.ToString(), ct);
+        }
+
+        private void PersistMatchEvents(AiAnalysisResult result, List<VertexEvent> events)
+        {
+            var existing = _context.MatchEvents.Where(e => e.AiAnalysisResultId == result.Id);
+            _context.MatchEvents.RemoveRange(existing);
+
+            int i = 0;
+            foreach (var e in events)
+            {
+                _context.MatchEvents.Add(new MatchEvent
+                {
+                    AiAnalysisResultId = result.Id,
+                    StartTimestampMs = e.StartTimestampMs,
+                    EndTimestampMs = e.EndTimestampMs,
+                    Actor = ParseEnum(e.Actor, EventActor.Student),
+                    TechniqueCategory = string.IsNullOrWhiteSpace(e.TechniqueCategory) ? "Transition" : e.TechniqueCategory,
+                    TechniqueName = e.TechniqueName,
+                    PositionBefore = e.PositionBefore,
+                    PositionAfter = e.PositionAfter,
+                    Outcome = ParseEnum(e.Outcome, EventOutcome.InProgress),
+                    GuardType = e.GuardType,
+                    SubmissionType = e.SubmissionType,
+                    ActionsDescription = e.ActionsDescription,
+                    Confidence = e.Confidence,
+                    SequenceIndex = i++,
+                });
+            }
+        }
+
+        private void PersistCoachingReport(AiAnalysisResult result, VertexCoachingReport report)
+        {
+            var existing = _context.CoachingReports
+                .Include(r => r.Strengths)
+                .Include(r => r.Weaknesses)
+                .Include(r => r.PrescribedDrills)
+                .FirstOrDefault(r => r.AiAnalysisResultId == result.Id);
+            if (existing != null) _context.CoachingReports.Remove(existing);
+
+            // Enforce the PRD's hard limits in code (responseSchema min/maxItems is best-effort).
+            var strengths = report.KeyStrengths.Take(3).ToList();
+            var weaknesses = report.CriticalWeaknesses.Take(3).ToList();
+            var drills = report.PrescribedDrills.Take(3).ToList();
+
+            var entity = new CoachingReport
+            {
+                AiAnalysisResultId = result.Id,
+                MatchSummary = report.MatchSummary ?? string.Empty,
+                TechnicalGrade = Math.Clamp((int)Math.Round(report.TechnicalGrade), 0, 100),
+                GradeLabel = report.GradeLabel,
+                EliteTip = report.EliteTip,
+                Strengths = strengths.Select((s, idx) => new CoachingStrength
+                {
+                    Title = s.Title, Explanation = s.Explanation,
+                    TimestampStartMs = s.TimestampStartMs, TimestampEndMs = s.TimestampEndMs, SortOrder = idx,
+                }).ToList(),
+                Weaknesses = weaknesses.Select((w, idx) => new CoachingWeakness
+                {
+                    Title = w.Title, Explanation = w.Explanation,
+                    TimestampStartMs = w.TimestampStartMs, TimestampEndMs = w.TimestampEndMs,
+                    Severity = ParseEnum(w.Severity, WeaknessSeverity.Major), ScoringImpact = w.ScoringImpact, SortOrder = idx,
+                }).ToList(),
+                PrescribedDrills = drills.Select((d, idx) => new PrescribedDrill
+                {
+                    DrillName = d.DrillName, Instructions = d.Instructions, Goal = d.Goal, SortOrder = idx,
+                }).ToList(),
+            };
+            _context.CoachingReports.Add(entity);
+
+            // Mirror headline fields onto the analysis row for cheap list reads.
+            result.MatchSummary = entity.MatchSummary;
+            result.TechnicalGrade = entity.TechnicalGrade;
+            result.GradeLabel = entity.GradeLabel;
+            result.EliteTip = entity.EliteTip;
+        }
+
+        // ── Phase implementations ────────────────────────────────────────────
+
+        private async Task<string?> TryCreateCacheAsync(string fileUri, string mimeType, int videoId, CancellationToken ct)
+        {
+            // Caching is only reusable across phases when they share one model.
+            var cacheModel = _options.EventLogger.ModelId;
+            bool eligible = _options.Profiler.ModelId == cacheModel
+                && _options.Verifier.ModelId == cacheModel
+                && _options.HeadCoach.ModelId == cacheModel;
+            if (!eligible)
+            {
+                _logger.LogInformation("Context caching skipped for video {VideoId}: phases use differing models.", videoId);
+                return null;
+            }
+
+            try
+            {
+                // Matches the proven MyCoach pipeline: cache holds only the video (no videoMetadata/fps —
+                // fps is a prompt instruction), expiry via expireTime, on the global endpoint.
+                var expireTime = DateTime.UtcNow.AddMinutes(Math.Max(1, _options.ContextCacheTtlMinutes)).ToString("O");
+                var body = new
+                {
+                    model = _vertex.ModelResourcePath(cacheModel, _options.Location),
+                    displayName = $"analysis-{videoId}",
+                    expireTime,
+                    contents = new[]
+                    {
+                        new
+                        {
+                            role = "user",
+                            parts = new object[]
+                            {
+                                new { fileData = new { mimeType, fileUri } },
+                            },
+                        },
+                    },
+                };
+                return await _vertex.CreateCachedContentAsync(body, _options.Location, ct);
+            }
+            catch (Exception ex)
+            {
+                // Short videos may fall below the cache token minimum; fall back to per-phase fileData.
+                _logger.LogWarning(ex, "Context cache creation failed for video {VideoId}; falling back to per-phase fileData.", videoId);
+                return null;
+            }
+        }
+
+        private async Task<string> RunProfilerAsync(string? cacheName, string fileUri, string mimeType, string studentIdentifier, CancellationToken ct)
+        {
+            var prompt = PipelinePrompts.Profiler(studentIdentifier);
+            var body = BuildBody(cacheName, fileUri, mimeType, prompt, BuildTextGenerationConfig(_options.Profiler));
+            var response = await _vertex.GenerateContentAsync(_options.Profiler.ModelId, _options.Location, body, ct);
+            return _vertex.ExtractText(response).Trim();
+        }
+
+        private async Task<List<VertexEvent>> RunEventLoggerAsync(string? cacheName, string fileUri, string mimeType, string visualDna, CancellationToken ct)
+        {
+            var fps = _options.EventLogger.Fps > 0 ? _options.EventLogger.Fps : 3;
+            var genConfig = BuildJsonGenerationConfig(_options.EventLogger, PipelineSchemas.EventsSchema());
+
+            var events = await EventLoggerCallAsync(cacheName, fileUri, mimeType, PipelinePrompts.EventLogger(visualDna, fps), genConfig, ct);
+            if (events.Count == 0)
+            {
+                // Proven robustness step: a simplified prompt when the structured pass yields nothing.
+                _logger.LogWarning("Event Logger returned 0 events — retrying with simplified prompt.");
+                events = await EventLoggerCallAsync(cacheName, fileUri, mimeType, PipelinePrompts.EventLoggerFallback(), genConfig, ct);
+            }
+            return events;
+        }
+
+        private async Task<List<VertexEvent>> EventLoggerCallAsync(string? cacheName, string fileUri, string mimeType, string prompt, object genConfig, CancellationToken ct)
+        {
+            var body = BuildBody(cacheName, fileUri, mimeType, prompt, genConfig);
+            var response = await _vertex.GenerateContentAsync(_options.EventLogger.ModelId, _options.Location, body, ct);
+            return ParseEvents(_vertex.ExtractText(response));
+        }
+
+        private async Task<List<VertexEvent>> RunVerifierAsync(string? cacheName, string fileUri, string mimeType, List<VertexEvent> rawEvents, string visualDna, CancellationToken ct)
+        {
+            if (rawEvents.Count == 0) return rawEvents;
+            var eventsJson = JsonSerializer.Serialize(new VertexEventsResponse { Events = rawEvents });
+            var prompt = PipelinePrompts.Verifier(visualDna, eventsJson);
+            var genConfig = BuildJsonGenerationConfig(_options.Verifier, PipelineSchemas.EventsSchema());
+            var body = BuildBody(cacheName, fileUri, mimeType, prompt, genConfig);
+            var response = await _vertex.GenerateContentAsync(_options.Verifier.ModelId, _options.Location, body, ct);
+            var verified = ParseEvents(_vertex.ExtractText(response));
+            // Defensive: if the verifier returned nothing usable, keep the raw events rather than losing data.
+            return verified.Count > 0 ? verified : rawEvents;
+        }
+
+        private async Task<VertexCoachingReport> RunHeadCoachAsync(string? cacheName, string fileUri, string mimeType, List<VertexEvent> events, string visualDna, Fighter? fighter, CancellationToken ct)
+        {
+            var eventsJson = JsonSerializer.Serialize(new VertexEventsResponse { Events = events });
+            var prompt = PipelinePrompts.HeadCoach(visualDna, eventsJson, fighter);
+            var genConfig = BuildJsonGenerationConfig(_options.HeadCoach, PipelineSchemas.CoachingReportSchema());
+            var body = BuildBody(cacheName, fileUri, mimeType, prompt, genConfig);
+            var response = await _vertex.GenerateContentAsync(_options.HeadCoach.ModelId, _options.Location, body, ct);
+            var text = CleanJsonFromMarkdown(_vertex.ExtractText(response));
+            return JsonSerializer.Deserialize<VertexCoachingReport>(text, ParseOptions)
+                ?? throw new InvalidOperationException("Head Coach returned unparseable coaching report JSON.");
+        }
+
+        // ── Request body builder ─────────────────────────────────────────────
+
+        private static object BuildBody(string? cacheName, string fileUri, string mimeType, string prompt, object generationConfig)
+        {
+            if (cacheName != null)
+            {
+                // Video lives in the cache; only the per-phase prompt is sent (proven MyCoach pattern).
+                return new
+                {
+                    cachedContent = cacheName,
+                    contents = new[]
+                    {
+                        new { role = "user", parts = new object[] { new { text = prompt } } },
+                    },
+                    generationConfig,
+                    safetySettings = VertexRestClient.AllSafetyOff(),
+                };
+            }
+
+            // Fallback when no cache could be created: reference the gs:// video directly (no videoMetadata).
+            return new
+            {
+                contents = new[]
+                {
+                    new
+                    {
+                        role = "user",
+                        parts = new object[]
+                        {
+                            new { fileData = new { mimeType, fileUri } },
+                            new { text = prompt },
+                        },
+                    },
+                },
+                generationConfig,
+                safetySettings = VertexRestClient.AllSafetyOff(),
+            };
+        }
+
+        private static object BuildJsonGenerationConfig(PhaseModelOptions phase, JsonNode responseSchema) => new
+        {
+            temperature = phase.Temperature,
+            topP = 1.0f,
+            maxOutputTokens = phase.MaxOutputTokens,
+            responseMimeType = "application/json",
+            responseSchema,
+            thinkingConfig = new { thinkingBudget = phase.ThinkingBudget },
+        };
+
+        private static object BuildTextGenerationConfig(PhaseModelOptions phase) => new
+        {
+            temperature = phase.Temperature,
+            topP = 1.0f,
+            maxOutputTokens = phase.MaxOutputTokens,
+            thinkingConfig = new { thinkingBudget = phase.ThinkingBudget },
+        };
+
+        // ── Parsing utilities ────────────────────────────────────────────────
+
+        private List<VertexEvent> ParseEvents(string text)
+        {
+            var clean = CleanJsonFromMarkdown(text);
+            var parsed = JsonSerializer.Deserialize<VertexEventsResponse>(clean, ParseOptions);
+            return parsed?.Events ?? [];
+        }
+
+        private static TEnum ParseEnum<TEnum>(string? value, TEnum fallback) where TEnum : struct =>
+            Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed) ? parsed : fallback;
+
+        private string DetermineMimeType(string pathOrUri)
+        {
+            string extension;
+            if (pathOrUri.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                pathOrUri.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+                pathOrUri.StartsWith("gs://", StringComparison.OrdinalIgnoreCase))
+            {
+                extension = Path.GetExtension(new Uri(pathOrUri).AbsolutePath);
+            }
+            else
+            {
+                extension = Path.GetExtension(pathOrUri);
+            }
+
+            var provider = new FileExtensionContentTypeProvider();
+            if (string.IsNullOrEmpty(extension) || !provider.TryGetContentType(extension, out var contentType))
+            {
+                _logger.LogWarning("Could not determine MIME type for '{PathOrUri}'. Defaulting to 'video/mp4'.", pathOrUri);
+                contentType = "video/mp4";
+            }
+            return contentType;
+        }
+
+        private static string CleanJsonFromMarkdown(string rawJson)
+        {
+            if (string.IsNullOrWhiteSpace(rawJson)) return string.Empty;
+            var trimmed = rawJson.Trim();
+            if (trimmed.StartsWith("```", StringComparison.Ordinal))
+            {
+                var firstNewline = trimmed.IndexOf('\n');
+                if (firstNewline >= 0) trimmed = trimmed[(firstNewline + 1)..];
+                if (trimmed.EndsWith("```", StringComparison.Ordinal)) trimmed = trimmed[..^3];
+            }
+            return trimmed.Trim();
+        }
+    }
+}

--- a/VideoAnalysis.Server/Domain/AIServices/PipelinePrompts.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/PipelinePrompts.cs
@@ -1,0 +1,137 @@
+using SharedEntities.Models;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    /// <summary>
+    /// Per-phase prompt builders for the agentic pipeline. Each prompt inlines its role/system
+    /// instruction (kept out of the shared context cache so phases can differ), per the PRD §6.
+    /// </summary>
+    internal static class PipelinePrompts
+    {
+        public static string Profiler(string studentIdentifier) => $@"
+You are a Forensic Video Analyst specializing in combat sports footage. Your sole task is to
+identify a specific athlete and document their unique visual characteristics with enough detail
+that another analyst could unerringly pick them out in any frame. Ignore all technical grappling actions.
+
+Watch the opening segment of this video. Locate the athlete matching this description:
+'{studentIdentifier}'.
+
+Generate a hyper-detailed, immutable 'Visual DNA' profile of this specific athlete. Include ALL of
+the following when visible:
+- Gi/rashguard: color, brand, sleeve length, any distinguishing wear/damage
+- Belt: color, stripe count, knot style
+- Physical: hair color/style, skin tone, body type, approximate height relative to opponent
+- Distinguishing marks: visible team patches and their locations, sponsor logos, ankle supports,
+  knee braces, athletic tape on fingers or joints, ear guards
+- Movement signature: dominant stance (orthodox/southpaw), posture tendency
+
+Return ONLY a single descriptive paragraph. No bullet points. No headers. No analysis.";
+
+        public static string EventLogger(string visualDna, int fpsRate) => $@"
+You are a meticulous grappling play-by-play logger and an expert BJJ black belt instructor.
+Watch this complete BJJ match video from start to finish and log every significant action.
+
+STUDENT IDENTIFICATION:
+The student athlete matches this visual profile:
+{visualDna}
+Every 30 seconds of video, re-confirm which athlete is the student. If uncertain, set confidence
+to 0.3 or lower for those events.
+
+WHAT TO LOG:
+- Every positional change (e.g., standing to guard, guard to mount)
+- Every technique attempt — successful or failed (takedowns, sweeps, passes, submissions, escapes)
+- Every transition and scramble
+- Actions by BOTH the student and their opponent
+You MUST log at least one event for every 30 seconds of video. A typical 2-minute match should
+produce 8-20 events minimum.
+
+HOW TO LOG:
+- Use absolute video timestamps in milliseconds from the start of the video
+- Attribute each action to 'Student' or 'Opponent' based on the visual profile above
+- Assess your confidence (0.0 to 1.0) as the minimum of: actor attribution accuracy, technique
+  classification accuracy, and position identification accuracy
+- Analyze at a minimum of {fpsRate} frames per second — do not skip frames during scrambles
+
+IMPORTANT: You must return a JSON object with an 'events' array. The array must NOT be empty.
+Even if the video is unclear, log what you can observe with lower confidence scores.";
+
+        public static string EventLoggerFallback() => @"
+Watch this BJJ match video and describe every action you see, in order.
+
+For each action, provide:
+- When it happens (start and end timestamps in milliseconds)
+- Who does it: 'Student' (the person identified in the previous analysis) or 'Opponent'
+- What type of action it is (e.g., Takedown, Pass, Sweep, Submission, Escape, Transition, Control)
+- What specific technique is used (e.g., Double Leg, Armbar, Knee Slice)
+- What position they were in before and after the action
+- Whether it was successful, failed, or partial
+- A brief description of what happened
+- How confident you are (0.0 to 1.0)
+
+You MUST return at least one event. Describe everything you can observe in the video.";
+
+        public static string Verifier(string visualDna, string eventsJson) => $@"
+You are a BJJ match identity verification specialist. You are given a list of timestamped events
+from a BJJ match and the Visual DNA profile of the student athlete. Your job is to verify each event
+by examining the video at the specified timestamp and confirming:
+1. Is the 'actor' field correct? Does the person performing this action match (or not match) the Visual DNA?
+2. Are 'position_before' and 'position_after' accurate for what you see?
+3. Is the 'technique_category' correct?
+
+You may CORRECT any field you find inaccurate. You must LOWER the confidence score for any event
+where verification is ambiguous (camera angle obscures the view, athletes tangled). Do NOT add new
+events. Do NOT remove events. Only correct existing ones.
+
+=== STUDENT VISUAL DNA ===
+{visualDna}
+
+=== EVENTS TO VERIFY ===
+{eventsJson}
+
+For each event, examine the video at the specified timestamp range. If an event's actor was wrong,
+swap it. If a position was misidentified, correct it. If you cannot verify with confidence, set
+confidence to 0.3 or lower. Return the complete event list (same schema) with corrections applied.";
+
+        public static string HeadCoach(string visualDna, string eventsJson, Fighter? fighter)
+        {
+            var belt = fighter?.BelkRank.ToString() ?? "unknown";
+            var experience = fighter?.Experience.ToString() ?? "unknown";
+            var stamina = fighter?.MaxWorkoutDuration.ToString() ?? "unknown";
+            var height = fighter?.Height.ToString("F0") ?? "unknown";
+            var weight = fighter?.Weight.ToString("F1") ?? "unknown";
+
+            return $@"
+You are an expert Brazilian Jiu-Jitsu Head Coach and IBJJF Black Belt competitor. You have access to
+both the match video and a structured event log verified for accuracy. Analyze the student's
+performance and produce actionable coaching feedback. Prioritize score-losing technical errors.
+Reference specific moments in the video (millisecond timestamps) when citing strengths and weaknesses,
+so the student can rewatch the exact moment.
+
+=== STUDENT VISUAL DNA ===
+{visualDna}
+
+=== VERIFIED EVENT LOG ===
+{eventsJson}
+
+=== STUDENT PROFILE ===
+Belt level: {belt}
+Experience: {experience}
+Stamina: {stamina} minutes
+Height: {height} cm
+Weight: {weight} kg
+
+=== INSTRUCTIONS ===
+Return structured coaching feedback matching the provided schema:
+1. match_summary: A narrative paragraph summarizing the match flow and outcome.
+2. key_strengths (max 3): Specific things done well, with video timestamps (ms).
+3. critical_weaknesses (max 3): Specific errors with video timestamp ranges (ms), severity level
+   (Critical/Major/Minor), and IBJJF scoring impact where applicable.
+4. prescribed_drills (exactly 3): Targeted positional sparring drills for the weaknesses.
+5. technical_grade: 0-100 score reflecting overall technical execution.
+6. grade_label: One-line descriptor (e.g., 'Solid Fundamentals', 'Raw but Aggressive').
+7. elite_tip: ONE highly specific '1% detail' a black belt would notice. Single sentence.
+
+Use millisecond timestamps for all time references.";
+        }
+    }
+}

--- a/VideoAnalysis.Server/Domain/AIServices/PipelineSchemas.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/PipelineSchemas.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Nodes;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    /// <summary>
+    /// Vertex <c>responseSchema</c> definitions, mirroring the proven MyCoach mobile pipeline
+    /// (validated with real uploads). Note: <c>technique_category</c> / <c>position_*</c> use a
+    /// description hint rather than a hard <c>enum</c> — this keeps the taxonomy free-evolving and
+    /// avoids Vertex rejecting near-miss values; only <c>actor</c>/<c>outcome</c>/<c>severity</c> are
+    /// hard enums. Parsed from raw JSON so field names reach Vertex verbatim.
+    /// </summary>
+    internal static class PipelineSchemas
+    {
+        public static JsonNode EventsSchema() => JsonNode.Parse("""
+        {
+          "type": "OBJECT",
+          "required": ["events"],
+          "properties": {
+            "events": {
+              "type": "ARRAY",
+              "description": "List of all match events observed in the video, in chronological order",
+              "items": {
+                "type": "OBJECT",
+                "required": ["start_timestamp_ms","end_timestamp_ms","actor","technique_category","technique_name","position_before","position_after","outcome","actions_description","confidence"],
+                "properties": {
+                  "start_timestamp_ms": { "type": "INTEGER", "description": "Absolute milliseconds from start of video when this action begins" },
+                  "end_timestamp_ms": { "type": "INTEGER", "description": "Absolute milliseconds from start of video when this action ends" },
+                  "actor": { "type": "STRING", "description": "Who performs this action", "enum": ["Student","Opponent"] },
+                  "technique_category": { "type": "STRING", "description": "Category of technique. Use one of: Takedown, Submission, Sweep, Pass, Escape, Transition, Control, Defense, GuardPull, Scramble, StandUp, GripFight" },
+                  "technique_name": { "type": "STRING", "description": "Specific technique name, e.g. 'Double Leg', 'Armbar from Guard', 'Knee Slice Pass'" },
+                  "position_before": { "type": "STRING", "description": "Position at the start of this action. Use one of: Standing, OpenGuard, ClosedGuard, HalfGuard, SideControl, Mount, BackControl, Turtle, KneeOnBelly, NorthSouth, FiftyFifty, Crucifix, Scramble" },
+                  "position_after": { "type": "STRING", "description": "Position at the end of this action. Use one of: Standing, OpenGuard, ClosedGuard, HalfGuard, SideControl, Mount, BackControl, Turtle, KneeOnBelly, NorthSouth, FiftyFifty, Crucifix, Scramble" },
+                  "outcome": { "type": "STRING", "description": "Result of this action", "enum": ["Successful","Failed","Partial","Countered","InProgress"] },
+                  "guard_type": { "type": "STRING", "nullable": true, "description": "Specific guard variant if position is a guard (e.g. 'De La Riva', 'Spider', 'Butterfly'). Null when not in guard." },
+                  "submission_type": { "type": "STRING", "nullable": true, "description": "Specific submission name when technique_category is Submission (e.g. 'Rear Naked Choke', 'Armbar'). Null otherwise." },
+                  "actions_description": { "type": "STRING", "description": "Free-text description of what happened during this event" },
+                  "confidence": { "type": "NUMBER", "description": "Confidence score 0.0-1.0, the minimum of actor attribution, technique classification, and position identification confidence" }
+                }
+              }
+            }
+          }
+        }
+        """)!;
+
+        public static JsonNode CoachingReportSchema() => JsonNode.Parse("""
+        {
+          "type": "OBJECT",
+          "required": ["match_summary","key_strengths","critical_weaknesses","prescribed_drills","technical_grade","grade_label","elite_tip"],
+          "properties": {
+            "match_summary": { "type": "STRING" },
+            "technical_grade": { "type": "NUMBER" },
+            "grade_label": { "type": "STRING" },
+            "elite_tip": { "type": "STRING" },
+            "key_strengths": {
+              "type": "ARRAY",
+              "items": {
+                "type": "OBJECT",
+                "required": ["title","explanation","timestamp_start_ms","timestamp_end_ms"],
+                "properties": {
+                  "title": { "type": "STRING" },
+                  "explanation": { "type": "STRING" },
+                  "timestamp_start_ms": { "type": "INTEGER" },
+                  "timestamp_end_ms": { "type": "INTEGER" }
+                }
+              }
+            },
+            "critical_weaknesses": {
+              "type": "ARRAY",
+              "items": {
+                "type": "OBJECT",
+                "required": ["title","explanation","timestamp_start_ms","timestamp_end_ms","severity"],
+                "properties": {
+                  "title": { "type": "STRING" },
+                  "explanation": { "type": "STRING" },
+                  "timestamp_start_ms": { "type": "INTEGER" },
+                  "timestamp_end_ms": { "type": "INTEGER" },
+                  "severity": { "type": "STRING", "enum": ["Critical","Major","Minor"] },
+                  "scoring_impact": { "type": "STRING", "nullable": true }
+                }
+              }
+            },
+            "prescribed_drills": {
+              "type": "ARRAY",
+              "items": {
+                "type": "OBJECT",
+                "required": ["drill_name","instructions","goal"],
+                "properties": {
+                  "drill_name": { "type": "STRING" },
+                  "instructions": { "type": "STRING" },
+                  "goal": { "type": "STRING" }
+                }
+              }
+            }
+          }
+        }
+        """)!;
+    }
+}

--- a/VideoAnalysis.Server/Domain/AIServices/VertexRestClient.cs
+++ b/VideoAnalysis.Server/Domain/AIServices/VertexRestClient.cs
@@ -1,0 +1,185 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Google.Apis.Auth.OAuth2;
+using SharedEntities;
+
+namespace VideoAnalysis.Server.Domain.AIServices
+{
+    /// <summary>
+    /// Thin reusable client for the Vertex AI REST surface (<c>generateContent</c> and
+    /// <c>cachedContents</c>), authenticating with ADC/OAuth2 Bearer tokens. Extracted from the
+    /// token/HTTP plumbing in <see cref="GeminiService.GeminiVisionService"/> so the agentic pipeline
+    /// can reuse it. Unlike the single-shot service, the host is resolved per call from the supplied
+    /// <c>location</c> so the pipeline can target a REGIONAL endpoint (required for context caching).
+    /// </summary>
+    public interface IVertexRestClient
+    {
+        /// <summary>POST <c>:generateContent</c> for the given model/location, returns the raw response JSON.</summary>
+        Task<JsonElement> GenerateContentAsync(string modelId, string location, object body, CancellationToken ct);
+
+        /// <summary>POST <c>cachedContents</c>; <paramref name="cacheBody"/> must include the full model path. Returns the cache resource name.</summary>
+        Task<string> CreateCachedContentAsync(object cacheBody, string location, CancellationToken ct);
+
+        /// <summary>DELETE a context cache by its full resource name (<c>projects/.../cachedContents/id</c>).</summary>
+        Task DeleteCachedContentAsync(string cacheName, string location, CancellationToken ct);
+
+        /// <summary>Full model resource path used in cache bodies: <c>projects/{p}/locations/{loc}/publishers/google/models/{id}</c>.</summary>
+        string ModelResourcePath(string modelId, string location);
+
+        /// <summary>Extracts the last non-empty text part (thinking models emit thinking parts first).</summary>
+        string ExtractText(JsonElement response);
+    }
+
+    /// <inheritdoc cref="IVertexRestClient"/>
+    public class VertexRestClient : IVertexRestClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly GoogleCredential _credential;
+        private readonly string _projectId;
+        private readonly ILogger<VertexRestClient> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        };
+
+        public VertexRestClient(HttpClient httpClient, ILogger<VertexRestClient> logger)
+        {
+            _httpClient = httpClient;
+            // 4 sequential pro-model passes per pipeline run — give each call generous headroom.
+            _httpClient.Timeout = TimeSpan.FromMinutes(10);
+            _logger = logger;
+
+            _projectId = Global.AccessAppEnvironmentVariable(AppEnvironmentVariables.GoogleCloudProjectId);
+
+            // Same auth resolution as GeminiVisionService: SA key file if present, else ADC (keyless).
+            var keyPath = Environment.GetEnvironmentVariable("GoogleCloud__ServiceAccountKeyPath");
+            if (!string.IsNullOrEmpty(keyPath) && File.Exists(keyPath))
+            {
+                _credential = GoogleCredential.FromFile(keyPath)
+                    .CreateScoped("https://www.googleapis.com/auth/cloud-platform");
+                _logger.LogInformation("VertexRestClient: using service account key from {KeyPath}", keyPath);
+            }
+            else
+            {
+                _credential = GoogleCredential.GetApplicationDefault()
+                    .CreateScoped("https://www.googleapis.com/auth/cloud-platform");
+                _logger.LogInformation("VertexRestClient: using Application Default Credentials");
+            }
+        }
+
+        // ── URL builders ─────────────────────────────────────────────────────
+
+        private static string HostFor(string location) =>
+            string.Equals(location, "global", StringComparison.OrdinalIgnoreCase)
+                ? "https://aiplatform.googleapis.com"
+                : $"https://{location}-aiplatform.googleapis.com";
+
+        public string ModelResourcePath(string modelId, string location) =>
+            $"projects/{_projectId}/locations/{location}/publishers/google/models/{modelId}";
+
+        private string GenerateContentUrl(string modelId, string location) =>
+            $"{HostFor(location)}/v1/{ModelResourcePath(modelId, location)}:generateContent";
+
+        private string CachedContentsUrl(string location) =>
+            $"{HostFor(location)}/v1/projects/{_projectId}/locations/{location}/cachedContents";
+
+        // ── Public API ───────────────────────────────────────────────────────
+
+        public async Task<JsonElement> GenerateContentAsync(string modelId, string location, object body, CancellationToken ct)
+        {
+            return await PostJsonAsync(GenerateContentUrl(modelId, location), body, ct);
+        }
+
+        public async Task<string> CreateCachedContentAsync(object cacheBody, string location, CancellationToken ct)
+        {
+            var response = await PostJsonAsync(CachedContentsUrl(location), cacheBody, ct);
+            if (!response.TryGetProperty("name", out var nameProp) || nameProp.GetString() is not { Length: > 0 } cacheName)
+            {
+                throw new InvalidOperationException("cachedContents response did not contain a resource name.");
+            }
+            _logger.LogInformation("Created Vertex context cache {CacheName}", cacheName);
+            return cacheName;
+        }
+
+        public async Task DeleteCachedContentAsync(string cacheName, string location, CancellationToken ct)
+        {
+            var token = await GetAccessTokenAsync();
+            using var request = new HttpRequestMessage(HttpMethod.Delete, $"{HostFor(location)}/v1/{cacheName}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                // Cache cleanup is best-effort — log but do not throw (TTL expiry will reclaim it).
+                var errorBody = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogWarning("Failed to delete context cache {CacheName}. Status {Status}: {Body}",
+                    cacheName, (int)response.StatusCode, errorBody[..Math.Min(300, errorBody.Length)]);
+                return;
+            }
+            _logger.LogInformation("Deleted Vertex context cache {CacheName}", cacheName);
+        }
+
+        public string ExtractText(JsonElement response)
+        {
+            var parts = response
+                .GetProperty("candidates")[0]
+                .GetProperty("content")
+                .GetProperty("parts");
+
+            for (int i = parts.GetArrayLength() - 1; i >= 0; i--)
+            {
+                if (parts[i].TryGetProperty("text", out var textProp))
+                {
+                    var text = textProp.GetString();
+                    if (!string.IsNullOrWhiteSpace(text))
+                        return text;
+                }
+            }
+
+            throw new InvalidOperationException("Response contained no text in candidates[0].content.parts");
+        }
+
+        public static object[] AllSafetyOff() =>
+        [
+            new { category = "HARM_CATEGORY_HATE_SPEECH", threshold = "OFF" },
+            new { category = "HARM_CATEGORY_DANGEROUS_CONTENT", threshold = "OFF" },
+            new { category = "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold = "OFF" },
+            new { category = "HARM_CATEGORY_HARASSMENT", threshold = "OFF" },
+        ];
+
+        // ── HTTP helper ──────────────────────────────────────────────────────
+
+        private async Task<string> GetAccessTokenAsync()
+        {
+            var tokenAccess = _credential as ITokenAccess;
+            return await tokenAccess!.GetAccessTokenForRequestAsync();
+        }
+
+        private async Task<JsonElement> PostJsonAsync(string url, object body, CancellationToken ct)
+        {
+            var token = await GetAccessTokenAsync();
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            request.Content = JsonContent.Create(body, options: JsonOptions);
+
+            var response = await _httpClient.SendAsync(request, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogError("Vertex AI API error. Status: {StatusCode}, Body: {Body}",
+                    (int)response.StatusCode, errorBody[..Math.Min(500, errorBody.Length)]);
+                throw new HttpRequestException(
+                    $"Vertex AI request failed with {(int)response.StatusCode}: {errorBody[..Math.Min(500, errorBody.Length)]}",
+                    null,
+                    response.StatusCode);
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct);
+            return await JsonSerializer.DeserializeAsync<JsonElement>(stream, cancellationToken: ct);
+        }
+    }
+}

--- a/VideoAnalysis.Server/Helpers/AgenticAnalysisBackgroundJobService.cs
+++ b/VideoAnalysis.Server/Helpers/AgenticAnalysisBackgroundJobService.cs
@@ -1,0 +1,30 @@
+using Hangfire;
+using VideoAnalysis.Server.Domain.AIServices;
+
+namespace VideoAnalysis.Server.Helpers
+{
+    /// <summary>
+    /// Hangfire entry point for the agentic (v2) pipeline. Runs on a dedicated "vertex-pipeline"
+    /// queue whose worker count caps concurrent Vertex jobs (see Program.cs).
+    /// </summary>
+    public class AgenticAnalysisBackgroundJobService
+    {
+        private readonly IAgenticPipelineService _pipeline;
+        private readonly ILogger<AgenticAnalysisBackgroundJobService> _logger;
+
+        public AgenticAnalysisBackgroundJobService(
+            IAgenticPipelineService pipeline,
+            ILogger<AgenticAnalysisBackgroundJobService> logger)
+        {
+            _pipeline = pipeline;
+            _logger = logger;
+        }
+
+        [Queue("vertex-pipeline")]
+        public async Task ProcessAgenticAnalysisAsync(int videoId)
+        {
+            _logger.LogInformation("Starting agentic analysis pipeline for video {VideoId}.", videoId);
+            await _pipeline.RunPipelineAsync(videoId, CancellationToken.None);
+        }
+    }
+}

--- a/VideoAnalysis.Server/Models/Dtos/PipelineDtos.cs
+++ b/VideoAnalysis.Server/Models/Dtos/PipelineDtos.cs
@@ -1,0 +1,207 @@
+using System.Text.Json.Serialization;
+
+namespace VideoAnalysis.Server.Models.Dtos
+{
+    // ════════════════════════════════════════════════════════════════════════
+    //  Vertex response-parse DTOs (snake_case from the model's responseSchema)
+    // ════════════════════════════════════════════════════════════════════════
+
+    public class VertexEventsResponse
+    {
+        [JsonPropertyName("events")]
+        public List<VertexEvent> Events { get; set; } = [];
+    }
+
+    public class VertexEvent
+    {
+        [JsonPropertyName("start_timestamp_ms")]
+        public int StartTimestampMs { get; set; }
+
+        [JsonPropertyName("end_timestamp_ms")]
+        public int EndTimestampMs { get; set; }
+
+        [JsonPropertyName("actor")]
+        public string Actor { get; set; } = "Student";
+
+        [JsonPropertyName("technique_category")]
+        public string TechniqueCategory { get; set; } = "Transition";
+
+        [JsonPropertyName("technique_name")]
+        public string? TechniqueName { get; set; }
+
+        [JsonPropertyName("position_before")]
+        public string? PositionBefore { get; set; }
+
+        [JsonPropertyName("position_after")]
+        public string? PositionAfter { get; set; }
+
+        [JsonPropertyName("outcome")]
+        public string Outcome { get; set; } = "InProgress";
+
+        [JsonPropertyName("guard_type")]
+        public string? GuardType { get; set; }
+
+        [JsonPropertyName("submission_type")]
+        public string? SubmissionType { get; set; }
+
+        [JsonPropertyName("actions_description")]
+        public string? ActionsDescription { get; set; }
+
+        [JsonPropertyName("confidence")]
+        public double Confidence { get; set; }
+    }
+
+    public class VertexCoachingReport
+    {
+        [JsonPropertyName("match_summary")]
+        public string MatchSummary { get; set; } = string.Empty;
+
+        [JsonPropertyName("key_strengths")]
+        public List<VertexStrength> KeyStrengths { get; set; } = [];
+
+        [JsonPropertyName("critical_weaknesses")]
+        public List<VertexWeakness> CriticalWeaknesses { get; set; } = [];
+
+        [JsonPropertyName("prescribed_drills")]
+        public List<VertexDrill> PrescribedDrills { get; set; } = [];
+
+        [JsonPropertyName("technical_grade")]
+        public double TechnicalGrade { get; set; }
+
+        [JsonPropertyName("grade_label")]
+        public string? GradeLabel { get; set; }
+
+        [JsonPropertyName("elite_tip")]
+        public string? EliteTip { get; set; }
+    }
+
+    public class VertexStrength
+    {
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("explanation")]
+        public string? Explanation { get; set; }
+
+        [JsonPropertyName("timestamp_start_ms")]
+        public int? TimestampStartMs { get; set; }
+
+        [JsonPropertyName("timestamp_end_ms")]
+        public int? TimestampEndMs { get; set; }
+    }
+
+    public class VertexWeakness
+    {
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("explanation")]
+        public string? Explanation { get; set; }
+
+        [JsonPropertyName("timestamp_start_ms")]
+        public int? TimestampStartMs { get; set; }
+
+        [JsonPropertyName("timestamp_end_ms")]
+        public int? TimestampEndMs { get; set; }
+
+        [JsonPropertyName("severity")]
+        public string Severity { get; set; } = "Major";
+
+        [JsonPropertyName("scoring_impact")]
+        public string? ScoringImpact { get; set; }
+    }
+
+    public class VertexDrill
+    {
+        [JsonPropertyName("drill_name")]
+        public string DrillName { get; set; } = string.Empty;
+
+        [JsonPropertyName("instructions")]
+        public string? Instructions { get; set; }
+
+        [JsonPropertyName("goal")]
+        public string? Goal { get; set; }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    //  Frontend-facing API DTOs (serialized camelCase; enums exposed as strings
+    //  to match the TS union types). Read/write services map enum ↔ string.
+    // ════════════════════════════════════════════════════════════════════════
+
+    public class AnalysisV2Dto
+    {
+        public int? Id { get; set; }
+        public int VideoId { get; set; }
+        public string? VisualDna { get; set; }
+        public string PipelineStatus { get; set; } = "NotStarted";
+        public int? TechnicalGrade { get; set; }
+        public string? GradeLabel { get; set; }
+        public string? EliteTip { get; set; }
+        public string? MatchSummary { get; set; }
+        public List<MatchEventDto> MatchEvents { get; set; } = [];
+        public CoachingReportDto? CoachingReport { get; set; }
+    }
+
+    public class MatchEventDto
+    {
+        public int? Id { get; set; }
+        public int StartTimestampMs { get; set; }
+        public int EndTimestampMs { get; set; }
+        public string Actor { get; set; } = "Student";
+        public string TechniqueCategory { get; set; } = "Transition";
+        public string? TechniqueName { get; set; }
+        public string? PositionBefore { get; set; }
+        public string? PositionAfter { get; set; }
+        public string Outcome { get; set; } = "InProgress";
+        public string? GuardType { get; set; }
+        public string? SubmissionType { get; set; }
+        public string? ActionsDescription { get; set; }
+        public double Confidence { get; set; }
+    }
+
+    public class CoachingReportDto
+    {
+        public int? Id { get; set; }
+        public string MatchSummary { get; set; } = string.Empty;
+        public int TechnicalGrade { get; set; }
+        public string? GradeLabel { get; set; }
+        public string? EliteTip { get; set; }
+        public List<CoachingStrengthDto> KeyStrengths { get; set; } = [];
+        public List<CoachingWeaknessDto> CriticalWeaknesses { get; set; } = [];
+        public List<PrescribedDrillDto> PrescribedDrills { get; set; } = [];
+    }
+
+    public class CoachingStrengthDto
+    {
+        public int? Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Explanation { get; set; }
+        public int? TimestampStartMs { get; set; }
+        public int? TimestampEndMs { get; set; }
+    }
+
+    public class CoachingWeaknessDto
+    {
+        public int? Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Explanation { get; set; }
+        public int? TimestampStartMs { get; set; }
+        public int? TimestampEndMs { get; set; }
+        public string Severity { get; set; } = "Major";
+        public string? ScoringImpact { get; set; }
+    }
+
+    public class PrescribedDrillDto
+    {
+        public int? Id { get; set; }
+        public string DrillName { get; set; } = string.Empty;
+        public string? Instructions { get; set; }
+        public string? Goal { get; set; }
+    }
+
+    public class AnalysisStatusDto
+    {
+        public string Status { get; set; } = "NotStarted";
+        public string? Error { get; set; }
+    }
+}

--- a/VideoAnalysis.Server/Program.cs
+++ b/VideoAnalysis.Server/Program.cs
@@ -20,6 +20,7 @@ using VideoAnalysis.Server.Domain.GeminiService;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
 using VideoAnalysis.Server.Domain.AIServices;
+using VideoAnalysis.Server.Configuration;
 using Hangfire;
 using Hangfire.PostgreSql;
 
@@ -62,6 +63,15 @@ namespace VideoAnalysis.Server
             builder.Services.AddScoped<CurriculumRecommendationService>();
             builder.Services.AddHttpClient<IXAIService, XAIService>();
             builder.Services.AddTransient<VideoAnalysisBackgroundJobService>();
+
+            // Agentic (v2) analysis pipeline
+            builder.Services.Configure<VertexAiPipelineOptions>(
+                builder.Configuration.GetSection(VertexAiPipelineOptions.SectionName));
+            builder.Services.AddHttpClient<IVertexRestClient, VertexRestClient>();
+            builder.Services.AddScoped<IAgenticPipelineService, AgenticPipelineService>();
+            builder.Services.AddScoped<AgenticAnalysisReadService>();
+            builder.Services.AddScoped<AgenticAnalysisWriteService>();
+            builder.Services.AddTransient<AgenticAnalysisBackgroundJobService>();
 
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -239,7 +249,21 @@ namespace VideoAnalysis.Server
                         SchemaName = "hangfire"
                     });
             });
-            builder.Services.AddHangfireServer();
+            // Default server handles the standard queue (single-shot v1 jobs).
+            builder.Services.AddHangfireServer(opts =>
+            {
+                opts.Queues = ["default"];
+            });
+            // Dedicated server caps concurrent agentic (v2) Vertex jobs to avoid quota/429s.
+            var pipelineOptions = builder.Configuration
+                .GetSection(VertexAiPipelineOptions.SectionName)
+                .Get<VertexAiPipelineOptions>() ?? new VertexAiPipelineOptions();
+            builder.Services.AddHangfireServer(opts =>
+            {
+                opts.ServerName = "vertex-pipeline-server";
+                opts.Queues = ["vertex-pipeline"];
+                opts.WorkerCount = Math.Max(1, pipelineOptions.MaxConcurrentJobs);
+            });
 
             builder.Services.AddHealthChecks();
 

--- a/VideoAnalysis.Server/appsettings.json
+++ b/VideoAnalysis.Server/appsettings.json
@@ -31,6 +31,19 @@
     "TextModel": "gemini-3.1-flash-lite-preview",
     "VideoAnalysisPrompt": ""
   },
+  "VertexAi": {
+    "Pipeline": {
+      "Enabled": true,
+      "Location": "global",
+      "ContextCacheTtlMinutes": 30,
+      "ConfidenceThresholdForReview": 0.7,
+      "MaxConcurrentJobs": 2,
+      "Profiler": { "ModelId": "gemini-3.1-pro-preview", "Fps": 1, "Temperature": 0.1, "MaxOutputTokens": 1024, "ThinkingBudget": 8192 },
+      "EventLogger": { "ModelId": "gemini-3.1-pro-preview", "Fps": 4, "Temperature": 0.2, "MaxOutputTokens": 65535, "ThinkingBudget": 16384 },
+      "Verifier": { "ModelId": "gemini-3.1-pro-preview", "Fps": 0, "Temperature": 0.1, "MaxOutputTokens": 65535, "ThinkingBudget": 4096 },
+      "HeadCoach": { "ModelId": "gemini-3.1-pro-preview", "Fps": 0, "Temperature": 0.4, "MaxOutputTokens": 8192, "ThinkingBudget": 16384 }
+    }
+  },
   "XAIGROK_API_KEY": "",
   "XAIGROK_ENDPOINT": ""
 }

--- a/docs/IVertexAiService.cs
+++ b/docs/IVertexAiService.cs
@@ -1,0 +1,65 @@
+using MyCoach.Application.Pipeline.Models;
+using MyCoach.Domain.Entities;
+
+namespace MyCoach.Application.Interfaces;
+
+public interface IVertexAiService
+{
+    /// <summary>Phase 1: Create context cache and generate Visual DNA.</summary>
+    Task<(string CacheName, string VisualDna)> CreateCacheAndGenerateVisualDnaAsync(
+        string videoGcsUri,
+        string studentIdentifier,
+        CancellationToken ct);
+
+    /// <summary>Phase 2: Full-video event logging using cached video.</summary>
+    Task<List<RawMatchEvent>> LogEventsAsync(
+        string cacheName,
+        string visualDna,
+        CancellationToken ct);
+
+    /// <summary>Phase 3: Verify events against Visual DNA using cached video.</summary>
+    Task<List<RawMatchEvent>> VerifyEventsAsync(
+        string cacheName,
+        string visualDna,
+        List<RawMatchEvent> events,
+        CancellationToken ct);
+
+    /// <summary>Phase 4: Generate coaching report using cached video + verified events.</summary>
+    Task<CoachingResult> GenerateCoachingReportAsync(
+        string cacheName,
+        string verifiedEventsJson,
+        string? beltLevel,
+        string? experienceLevel,
+        string? primaryGoal,
+        int? staminaMinutes,
+        decimal? heightCm,
+        decimal? weightKg,
+        CancellationToken ct);
+
+    /// <summary>Delete a context cache resource.</summary>
+    Task DeleteCacheAsync(string cacheName, CancellationToken ct);
+
+    /// <summary>
+    /// Phase 2.8 v2 (ADR-054 §5) — single-shot structured extraction from a
+    /// document already in GCS. Used by
+    /// <see cref="IMemberDocumentExtractor"/>'s LLM-fallback branch for
+    /// PDF / Word / header-less spreadsheets where deterministic parsing
+    /// won't work. Builds a Gemini request with a single <c>fileData</c>
+    /// part referencing the GCS object, applies the supplied JSON Schema
+    /// as <c>responseSchema</c>, and returns Gemini's response text — the
+    /// caller deserializes into its own DTO shape so this interface stays
+    /// free of feature-specific types.
+    ///
+    /// <paramref name="responseSchema"/> is the JSON Schema literal the
+    /// extractor wants enforced (the same shape passed today to
+    /// <c>responseSchema</c> in <see cref="VerifyEventsAsync"/> +
+    /// <see cref="GenerateCoachingReportAsync"/> — built as an anonymous
+    /// object or <see cref="System.Collections.Generic.IDictionary{TKey,TValue}"/>).
+    /// </summary>
+    Task<string> ExtractStructuredAsync(
+        string gcsUri,
+        string mimeType,
+        string promptText,
+        object responseSchema,
+        CancellationToken ct);
+}

--- a/docs/MyCoach-backend-MVP-PRD.md
+++ b/docs/MyCoach-backend-MVP-PRD.md
@@ -1,0 +1,1075 @@
+# MyCoach MVP – Backend Services PRD
+## .NET 10 API & AI Analysis Pipeline
+
+> **Status note (2026-05-06):** This PRD documents the shipped MyCoach MVP (B2C AI video-analysis pipeline). It predates the B2B2C portfolio pivot and the TKNQ "retention OS" positioning shift. For the current product direction (MyGym web SaaS + MyCoach mobile, multi-tenancy, retention engine, Stripe lock-in, App Store IAP for solo MyCoach), see `docs/proposals/feature-expansion-roadmap-v1.md` and ADR-035 / ADR-036 / ADR-037 in `docs/decisions.md`. This PRD remains accurate for the existing AI pipeline; it is **NOT being rewritten** — it is the historical MVP record.
+
+> Companion document to: `MyCoach-mobile-MVP-PRD.md`
+> Scope: Backend API, database schema, cloud infrastructure, and the agentic VLM video analysis pipeline required to serve the MyCoach Flutter mobile client.
+
+---
+
+## 1. Executive Summary
+
+| Item | Detail |
+|---|---|
+| **Backend Role** | Stateless REST API serving the Flutter mobile client. Owns all business logic, AI orchestration, and data persistence. |
+| **Core Infrastructure** | .NET 10 Web API · Supabase PostgreSQL · Google Cloud Storage · Vertex AI (Gemini) · Firebase Auth |
+| **Critical Pipeline** | A 5-phase agentic VLM pipeline that processes user-uploaded BJJ footage and returns structured, timestamped coaching analysis. |
+| **Design Philosophy** | Thin API surface, heavy AI orchestration layer. The mobile client is a display shell; all intelligence lives in the backend. |
+| **MVP Constraint** | No web annotator portal, no social features, no model fine-tuning pipeline. Upload → Analyze → Store → Return. |
+
+---
+
+## 2. Authentication Strategy
+
+### 2.1 Decision: Firebase Auth + Supabase PostgreSQL (Separate Concerns)
+
+> **Why not Supabase Auth?** Supabase Auth works well, but Firebase Auth provides out-of-the-box Google Sign-In SDK integration for Flutter with zero custom token exchange code on the mobile side. Since the mobile PRD mandates Google SSO via Firebase Auth, we keep it.
+
+> **Why not Firestore for the database?** The analysis pipeline produces deeply relational, structured data — events belong to analyses, analyses belong to users, drills reference weaknesses. This is a natural fit for PostgreSQL, not a document store. Firestore would require denormalization and complex client-side joins. Supabase free tier gives us a fully managed PostgreSQL instance with no operational overhead.
+
+**The correct MVP split:**
+
+| Concern | Service | Rationale |
+|---|---|---|
+| **Identity & Sessions** | Firebase Auth (Google Sign-In) | Zero-code Google SSO for Flutter. JWT tokens issued automatically. |
+| **Token Verification (Server)** | Firebase Admin SDK (in .NET) | Verify `idToken` from the mobile client on every API request. |
+| **All data storage** | Supabase PostgreSQL | Relational structure for users, analyses, events, and drills. |
+| **Video / media files** | Google Cloud Storage | Large binary storage; signed URLs for secure direct upload and streaming. |
+
+### 2.2 Authentication Flow
+
+```
+Mobile Client                  .NET API                      Firebase Auth
+     │                             │                               │
+     │── Google Sign-In ──────────────────────────────────────────►│
+     │◄── Firebase idToken ─────────────────────────────────────── │
+     │                             │                               │
+     │── POST /api/auth/session ──►│                               │
+     │   { idToken: "..." }        │── VerifyIdTokenAsync() ──────►│
+     │                             │◄── DecodedToken (uid, email) ─│
+     │                             │                               │
+     │                             │── Upsert user in PostgreSQL   │
+     │                             │   (firebase_uid, email, ...)  │
+     │◄── 200 { user, jwt } ───────│                               │
+```
+
+- Every subsequent API call includes the Firebase `idToken` in the `Authorization: Bearer <token>` header.
+- The .NET API verifies the token on every request using `FirebaseAuth.DefaultInstance.VerifyIdTokenAsync()`.
+- No custom session tokens or refresh logic needed — Firebase handles token lifecycle.
+- The PostgreSQL `users` table stores the `firebase_uid` as its primary external reference key.
+
+---
+
+## 3. Technology Stack
+
+| Layer | Technology | Version / Plan |
+|---|---|---|
+| **API Framework** | .NET Web API | 9 (Native AOT optional for non-AI endpoints) |
+| **Runtime / Hosting** | Google Cloud Run | Serverless container — scales to zero |
+| **Authentication** | Firebase Auth + Firebase Admin SDK for .NET | Latest stable |
+| **Database** | PostgreSQL via Supabase | Free tier (500MB, 2 CPU, 500MB RAM) |
+| **ORM** | Dapper (lightweight) or EF Core 9 | Prefer Dapper for explicit SQL control |
+| **Video Storage** | Google Cloud Storage (GCS) | Standard storage class |
+| **AI / VLM** | Vertex AI — Gemini API | Gemini Flash (Event Logger) + Gemini Pro (Auto-Profiler, Head Coach) |
+| **Background Jobs** | Cloud Tasks (GCP) OR in-process `IHostedService` | For async analysis pipeline execution |
+| **Logging** | Google Cloud Logging (structured JSON) | Via `Serilog` + GCP sink |
+
+---
+
+## 4. Database Schema (PostgreSQL / Supabase)
+
+### 4.1 Tables Overview
+
+```
+users
+  └─► analyses (one-to-many)
+        └─► match_events       (one-to-many — structured event log from pipeline)
+        └─► coaching_report    (one-to-one — final Head Coach synthesis)
+              └─► prescribed_drills  (one-to-many)
+```
+
+### 4.2 Schema Definitions
+
+```sql
+-- Users: synced from Firebase Auth on first login
+CREATE TABLE users (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    firebase_uid    TEXT NOT NULL UNIQUE,
+    email           TEXT NOT NULL,
+    display_name    TEXT,
+    avatar_url      TEXT,
+    belt_level      TEXT CHECK (belt_level IN ('white','blue','purple','brown','black')),
+    age             INT,
+    weight_kg       NUMERIC(5,1),
+    weekly_sessions INT,
+    primary_goal    TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Analyses: one per uploaded video session
+CREATE TABLE analyses (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    status              TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending','uploading','profiling',
+                                              'logging','verifying','coaching','complete','failed')),
+    source_type         TEXT NOT NULL CHECK (source_type IN ('local_upload','url_paste','record')),
+    source_url          TEXT,                        -- original URL if url_paste
+    gcs_raw_video_path  TEXT,                        -- GCS object path of uploaded video
+    gcs_thumbnail_path  TEXT,
+    video_duration_secs INT,
+    student_identifier  TEXT,                        -- user-provided description for Auto-Profiler
+    visual_dna          TEXT,                        -- Phase I output: immutable athlete profile
+    technical_grade     NUMERIC(5,2),                -- 0–100 score from Head Coach
+    grade_label         TEXT,                        -- e.g., "Solid Fundamentals"
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at        TIMESTAMPTZ
+);
+
+-- Match Events: structured output from Phase 2 (Event Logger), verified by Phase 3 (Event Verifier)
+CREATE TABLE match_events (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    analysis_id         UUID NOT NULL REFERENCES analyses(id) ON DELETE CASCADE,
+    start_timestamp_ms  BIGINT NOT NULL,             -- absolute ms from start of video
+    end_timestamp_ms    BIGINT NOT NULL,
+    actor               TEXT NOT NULL CHECK (actor IN ('Student','Opponent')),
+    technique_category  TEXT NOT NULL,               -- Takedown, Submission, Sweep, Pass, etc. (12 values)
+    technique_name      TEXT NOT NULL,               -- specific technique name (free-text)
+    position_before     TEXT NOT NULL,               -- position at start of action (13 values)
+    position_after      TEXT NOT NULL,               -- position at end of action (13 values)
+    outcome             TEXT NOT NULL,               -- Successful, Failed, Partial, Countered, InProgress
+    guard_type          TEXT,                         -- nullable: specific guard variant when in guard
+    submission_type     TEXT,                         -- nullable: specific submission name
+    actions_description TEXT NOT NULL,
+    confidence          NUMERIC(3,2) NOT NULL,       -- 0.00-1.00: VLM self-assessed confidence
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Coaching Report: one-to-one with analyses, output from Phase 4 (Head Coach)
+CREATE TABLE coaching_reports (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    analysis_id     UUID NOT NULL UNIQUE REFERENCES analyses(id) ON DELETE CASCADE,
+    match_summary   TEXT NOT NULL,
+    strengths       JSONB NOT NULL DEFAULT '[]',     -- [{title, explanation, timestamp_start_ms, timestamp_end_ms}]
+    weaknesses      JSONB NOT NULL DEFAULT '[]',     -- [{title, explanation, timestamp_start_ms, timestamp_end_ms, severity, scoring_impact?}]
+    elite_tip       TEXT,                            -- "The 1% Detail" — single expert insight
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Prescribed Drills: output from Head Coach, linked to coaching_reports
+CREATE TABLE prescribed_drills (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id       UUID NOT NULL REFERENCES coaching_reports(id) ON DELETE CASCADE,
+    drill_name      TEXT NOT NULL,
+    instructions    TEXT NOT NULL,
+    goal            TEXT NOT NULL,
+    sort_order      INT NOT NULL DEFAULT 0
+);
+
+-- Indexes
+CREATE INDEX idx_analyses_user_id ON analyses(user_id);
+CREATE INDEX idx_analyses_status ON analyses(status);
+CREATE INDEX idx_match_events_analysis_id ON match_events(analysis_id);
+CREATE INDEX idx_match_events_timestamp ON match_events(analysis_id, start_timestamp_ms);
+CREATE INDEX idx_match_events_confidence ON match_events(confidence);
+```
+
+---
+
+## 5. API Surface
+
+### 5.1 Base URL & Versioning
+
+```
+https://api.mycoach.app/api/v1/
+```
+
+All endpoints require `Authorization: Bearer <firebase_idToken>` unless marked `[Public]`.
+
+### 5.2 Endpoints
+
+#### Auth
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/auth/session` | Verify Firebase idToken, upsert user in PostgreSQL, return user profile. |
+
+#### User
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/users/me` | Return authenticated user's profile and stats. |
+| `PATCH` | `/users/me` | Update onboarding fields (belt level, weight, training frequency, goal). |
+
+#### Analyses
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/analyses/upload-url` | Request a GCS signed upload URL for a local video file. Returns `{ analysisId, uploadUrl }`. |
+| `POST` | `/analyses` | Submit analysis job. Body: `{ analysisId, sourceType, sourceUrl?, studentIdentifier }`. Triggers the async pipeline. |
+| `GET` | `/analyses` | List all analyses for the authenticated user (summary list for History tab). |
+| `GET` | `/analyses/{id}` | Get full analysis result including events, coaching report, and drills. |
+| `DELETE` | `/analyses/{id}` | Delete an analysis and associated GCS video. |
+
+#### Pipeline Status (Polling / SSE)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/analyses/{id}/status` | Lightweight status poll. Returns `{ status, progressLabel }`. Mobile client polls this during Screen 5 (Processing). |
+
+> **Note:** For MVP, simple polling (every 3s from the mobile client) is sufficient. Server-Sent Events (SSE) or WebSockets can be added post-MVP if latency is a concern.
+
+---
+
+## 6. Core Feature: Agentic VLM Analysis Pipeline v2
+
+> **Architecture Note:** Pipeline v2 replaces the original 5-phase chunking-based design (see ADR-016 in `docs/decisions.md`). Gemini 2.5+/3.1 models support up to 1 hour of video natively — the context window limitation that necessitated chunking no longer exists. This design leverages Gemini's **context caching** (`CachedContent` API) to reuse the uploaded video across all phases at ~90% input cost reduction.
+
+### 6.1 Pipeline Overview
+
+The pipeline uses 4 phases: one VLM call per phase, all sharing a single cached video resource. No FFmpeg chunking, no timestamp rebasing, no deduplication. Identity verification is handled by a dedicated lightweight verification phase instead of relying on thought signature relay across chunks.
+
+```
+[Video Upload Complete]
+        │
+        ▼
+┌──────────────────────────┐
+│  Phase 1                 │  Auto-Profiler Agent
+│  Context Cache Creation  │  Gemini Pro (High Thinking)
+│  + Visual DNA Generation │  → Creates: CachedContent resource
+│                          │  → Produces: visual_dna (text)
+└────────┬─────────────────┘
+         │  cache_name
+         ▼
+┌──────────────────────────┐
+│  Phase 2                 │  Event Logger Agent
+│  Full-Video Event        │  Gemini Pro (High Thinking)
+│  Logging (3-5 FPS)       │  Input: cached video + Visual DNA
+│                          │  → Produces: enriched event JSON
+└────────┬─────────────────┘
+         │  events[]
+         ▼
+┌──────────────────────────┐
+│  Phase 3                 │  Event Verifier Agent (NEW)
+│  Identity Verification   │  Gemini Pro (Low Thinking)
+│  Pass                    │  Input: cached video + events
+│                          │  → Produces: corrected event JSON
+└────────┬─────────────────┘
+         │  verified_events[]
+         ▼
+┌──────────────────────────┐
+│  Phase 4                 │  Head Coach Agent
+│  Video-Aware Coaching    │  Gemini Pro (High Thinking)
+│  Synthesis               │  Input: cached video + verified events
+│                          │  → Produces: coaching_report JSON
+└────────┬─────────────────┘
+         │
+         ▼
+[Delete CachedContent resource]
+[Persist to PostgreSQL → analysis.status = 'complete']
+```
+
+**Why chunking was eliminated:**
+- Gemini 3.1 processes up to 1 hour of video in a single call (our max is 20 min)
+- Chunking introduced identity drift at chunk boundaries — the primary accuracy problem
+- Timestamp rebasing (Phase IV) was error-prone and added complexity
+- Overlap window deduplication produced false merges in fast scramble sequences
+- Context caching makes full-video multi-phase processing cost-effective
+
+**Context caching lifecycle:**
+1. **Create** in Phase 1 via `GenAiCacheServiceClient.CreateCachedContentAsync()`
+2. **Reference** in Phases 2-4 via `request.CachedContent = cacheName`
+3. **Delete** after Phase 4 completes (or on pipeline failure in a `finally` block)
+
+### 6.2 Phase 1 — Auto-Profiler + Context Cache Creation
+
+**Purpose:** (a) Create a `CachedContent` resource containing the full video and system context, enabling cost-efficient reuse across all subsequent phases. (b) Generate an immutable Visual DNA profile of the student athlete.
+
+**Model:** Configurable, default `gemini-3-pro` (or `gemini-3.1-pro-preview-preview`)
+
+**FPS:** 1 (configurable) — sufficient for visual identification; higher FPS reserved for Phase 2
+
+**Two operations in this phase:**
+
+#### Operation A: Create Context Cache
+
+```csharp
+// Pseudocode: Context cache creation
+var cacheServiceClient = new GenAiCacheServiceClient();
+
+var videoUri = $"gs://{bucketName}/{analysis.GcsRawVideoPath}";
+
+var cachedContent = await cacheServiceClient.CreateCachedContentAsync(new CachedContent
+{
+    Model = $"projects/{projectId}/locations/{location}/publishers/google/models/{modelId}",
+    DisplayName = $"analysis-{analysis.Id}",
+    Contents =
+    {
+        new Content
+        {
+            Role = "user",
+            Parts =
+            {
+                new Part
+                {
+                    FileData = new FileData
+                    {
+                        MimeType = "video/mp4",
+                        FileUri = videoUri
+                    }
+                }
+            }
+        }
+    },
+    SystemInstruction = new Content
+    {
+        Parts =
+        {
+            new Part { Text = SYSTEM_INSTRUCTION }
+        }
+    },
+    ExpireTime = Timestamp.FromDateTime(
+        DateTime.UtcNow.AddMinutes(config.ContextCacheTtlMinutes) // default 30
+    )
+});
+
+string cacheName = cachedContent.Name; // e.g., "projects/.../cachedContents/abc123"
+```
+
+The `cacheName` is stored in memory for the pipeline run and passed to Phases 2-4. It is NOT persisted to the database.
+> Vertex AI note: any subsequent inference on this video cache must use the same model configuration as the cached model in this step
+
+#### Operation B: Generate Visual DNA
+
+**System Instruction:**
+```
+You are a Forensic Video Analyst specializing in combat sports footage. Your sole
+task is to identify a specific athlete and document their unique visual characteristics
+with enough detail that another analyst could unerringly pick them out in any frame.
+Ignore all technical grappling actions.
+```
+
+**Prompt template:**
+```
+Watch the opening segment of this video. Locate the athlete matching this description:
+'{studentIdentifier}'.
+
+Generate a hyper-detailed, immutable 'Visual DNA' profile of this specific athlete.
+Include ALL of the following when visible:
+- Gi/rashguard: color, brand, sleeve length, any distinguishing wear/damage
+- Belt: color, stripe count, knot style
+- Physical: hair color/style, skin tone, body type, approximate height relative to opponent
+- Distinguishing marks: visible team patches and their locations, sponsor logos,
+  ankle supports, knee braces, athletic tape on fingers or joints, ear guards
+- Movement signature: dominant stance (orthodox/southpaw), posture tendency
+
+Return ONLY a single descriptive paragraph. No bullet points. No headers. No analysis.
+```
+
+**Output:** Plain text paragraph stored as `analyses.visual_dna`.
+
+**Model Settings:**
+```json
+{
+  "model": "gemini-3.1-pro-preview",
+  "temperature": 0.1,
+  "max_output_tokens": 1024,
+  "thinking_config": { "thinking_budget": 8192 }
+}
+```
+
+### 6.3 Phase 2 — Event Logger (Full-Video Analysis)
+
+**Purpose:** Analyze the complete video in a single pass, logging all positional changes and technique executions with enriched structured output. No chunking — the full video is accessed via the context cache created in Phase 1.
+
+**Model:** Configurable, default `gemini-3.1-pro-preview`
+
+**FPS:** 3-5 (configurable) — **critical upgrade from v1's 1 FPS**. Fast BJJ scrambles, grip fights, and submission attempts can occur in under 1 second. At 1 FPS these are missed entirely. 3-5 FPS captures the granularity needed for accurate event logging.
+
+**Input:**
+- Cached video via `request.CachedContent = cacheName` (no re-upload of video bytes)
+- Visual DNA paragraph injected into the prompt
+
+**System Instruction:**
+```
+You are a meticulous grappling play-by-play logger and an expert Brazilian Jiu-Jitsu
+black belt instructor. You are analyzing a complete BJJ match video.
+
+You must strictly track the student matching the provided 'Visual DNA' profile.
+CRITICAL: Do not swap identities during scrambles. When uncertain, flag the event
+with a lower confidence score rather than guessing.
+
+Focus on: positional changes, technique attempts (successful and failed), sweeps,
+passes, submissions, escapes, and transitions. Log what BOTH athletes do, attributing
+each action to the correct actor.
+```
+
+**Prompt template:**
+```
+Analyze this complete BJJ match video from start to finish.
+
+=== STUDENT VISUAL DNA ===
+{visualDna}
+
+=== IDENTITY REINFORCEMENT ===
+Every 30 seconds of video time, re-confirm which athlete matches the Visual DNA
+before continuing your analysis. If at any point you lose certainty about which
+athlete is the student, set confidence to 0.3 or lower for those events.
+
+=== INSTRUCTIONS ===
+Log every significant positional change, technique attempted, technique suffered,
+and transition by BOTH the student and their opponent. Use absolute video timestamps
+(from the start of the video, not relative to any segment).
+
+For each event, assess your confidence (0.0 to 1.0) in:
+- Correct actor attribution (is this really the Student or the Opponent?)
+- Correct technique classification
+- Correct position identification
+
+Return the lower of these three as the event's confidence score.
+```
+
+**Enriched Structured Output Schema** (enforced via Vertex AI `responseSchema`):
+
+This is the **biggest schema change from v1**. New fields support the future HITL annotation portal and provide richer coaching data.
+
+| Field | Change vs v1 | Rationale |
+|-------|-------------|-----------|
+| `technique_category` | Renamed from `technique_type`, expanded enum (12 values) | Adds: `GuardPull`, `Scramble`, `StandUp`, `GripFight` |
+| `technique_name` | **NEW** (free-text) | Specific technique e.g. "Double Leg", "Armbar from Guard". Critical for HITL taxonomy building |
+| `position_before` | Replaces `position_scenario` | Where the action starts. Expanded enum (~13 values) with guard types |
+| `position_after` | **NEW** | Where the action ends. Enables positional flow analysis |
+| `outcome` | **NEW** (enum) | `Successful`, `Failed`, `Partial`, `Countered`, `InProgress` |
+| `guard_type` | **NEW** (nullable free-text) | Specific guard variant when in a guard position (e.g. "De La Riva", "Spider", "Butterfly") |
+| `submission_type` | **NEW** (nullable free-text) | Specific submission name when technique is Submission (e.g. "Rear Naked Choke", "Armbar") |
+| `confidence` | **NEW** (0.0-1.0) | VLM self-assessed confidence. Below threshold → auto-queue for HITL review |
+| `chunk_index` | **REMOVED** | No chunks in v2 |
+
+**PositionScenario enum** (~13 values — moderate expansion):
+`Standing`, `OpenGuard`, `ClosedGuard`, `HalfGuard`, `SideControl`, `Mount`, `BackControl`, `Turtle`, `KneeOnBelly`, `NorthSouth`, `FiftyFifty`, `Crucifix`, `Scramble`
+
+> Specific guard variants (De La Riva, Spider, Lasso, Butterfly, X-Guard, etc.) are captured in the nullable `guard_type` free-text field. This keeps the enum manageable for VLM accuracy while enabling HITL annotators to add specificity.
+
+**TechniqueCategory enum** (12 values — expanded from 8):
+`Takedown`, `Submission`, `Sweep`, `Pass`, `Escape`, `Transition`, `Control`, `Defense`, `GuardPull`, `Scramble`, `StandUp`, `GripFight`
+
+**Outcome enum** (new):
+`Successful`, `Failed`, `Partial`, `Countered`, `InProgress`
+
+**Full JSON schema for `responseSchema`:**
+```json
+{
+  "type": "object",
+  "required": ["events"],
+  "properties": {
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "start_timestamp_ms", "end_timestamp_ms", "actor",
+          "technique_category", "technique_name",
+          "position_before", "position_after",
+          "outcome", "actions_description", "confidence"
+        ],
+        "properties": {
+          "start_timestamp_ms": {
+            "type": "integer",
+            "description": "Absolute milliseconds from start of video"
+          },
+          "end_timestamp_ms": {
+            "type": "integer",
+            "description": "Absolute milliseconds from start of video"
+          },
+          "actor": {
+            "type": "string",
+            "enum": ["Student", "Opponent"]
+          },
+          "technique_category": {
+            "type": "string",
+            "enum": [
+              "Takedown", "Submission", "Sweep", "Pass", "Escape",
+              "Transition", "Control", "Defense", "GuardPull",
+              "Scramble", "StandUp", "GripFight"
+            ]
+          },
+          "technique_name": {
+            "type": "string",
+            "description": "Specific technique name, e.g. 'Double Leg', 'Armbar from Guard', 'Knee Slice Pass'"
+          },
+          "position_before": {
+            "type": "string",
+            "enum": [
+              "Standing", "OpenGuard", "ClosedGuard", "HalfGuard",
+              "SideControl", "Mount", "BackControl", "Turtle",
+              "KneeOnBelly", "NorthSouth", "FiftyFifty", "Crucifix", "Scramble"
+            ],
+            "description": "Position at the start of this action"
+          },
+          "position_after": {
+            "type": "string",
+            "enum": [
+              "Standing", "OpenGuard", "ClosedGuard", "HalfGuard",
+              "SideControl", "Mount", "BackControl", "Turtle",
+              "KneeOnBelly", "NorthSouth", "FiftyFifty", "Crucifix", "Scramble"
+            ],
+            "description": "Position at the end of this action"
+          },
+          "outcome": {
+            "type": "string",
+            "enum": ["Successful", "Failed", "Partial", "Countered", "InProgress"]
+          },
+          "guard_type": {
+            "type": "string",
+            "nullable": true,
+            "description": "Specific guard variant if position is a guard (e.g. 'De La Riva', 'Spider', 'Butterfly', 'X-Guard'). Null when not in guard."
+          },
+          "submission_type": {
+            "type": "string",
+            "nullable": true,
+            "description": "Specific submission name when technique_category is Submission (e.g. 'Rear Naked Choke', 'Armbar', 'Triangle'). Null otherwise."
+          },
+          "actions_description": {
+            "type": "string",
+            "description": "Free-text description of what happened"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "VLM self-assessed confidence in actor attribution, technique classification, and position identification. Minimum of the three."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Model Settings:**
+```json
+{
+  "model": "gemini-3.1-pro-previw",
+  "temperature": 0.2,
+  "max_output_tokens": 65535,
+  "top_p": 1.0,
+  "thinking_config": { "thinking_budget": 16384 }
+}
+```
+
+### 6.4 Phase 3 — Event Verifier (Identity Verification) — NEW
+
+**Purpose:** A lightweight verification pass that re-examines the video at each event's timestamp to verify that the `actor` field correctly matches the Visual DNA. This replaces the thought signature relay mechanism from v1, which was fragile across chunk boundaries.
+
+**Model:** `gemini-3.1-pro-preview` (this phase corrects, it doesn't create - but note that this phase must use the same model as the cached request's model, but it can use low thinking to save cost)
+
+**Why a separate phase?** The Event Logger (Phase 2) processes the video sequentially and may drift during fast scrambles. The Verifier examines each event independently, with the specific timestamp and Visual DNA fresh in context. It's a second pair of eyes, not a second full analysis.
+
+**Input:**
+- Cached video via `request.CachedContent = cacheName`
+- Complete event list from Phase 2
+- Visual DNA paragraph
+
+**System Instruction:**
+```
+You are a BJJ match identity verification specialist. You are given a list of
+timestamped events from a BJJ match and the Visual DNA profile of the student
+athlete. Your job is to verify each event by examining the video at the specified
+timestamp and confirming:
+
+1. Is the 'actor' field correct? Does the person performing this action match
+   (or not match) the Visual DNA?
+2. Are 'position_before' and 'position_after' accurate for what you see?
+3. Is the 'technique_category' correct?
+
+You may CORRECT any field you find inaccurate. You must LOWER the confidence
+score for any event where verification is ambiguous (e.g., camera angle obscures
+the view, athletes are tangled and hard to distinguish).
+
+Do NOT add new events. Do NOT remove events. Only correct existing ones.
+```
+
+**Prompt template:**
+```
+=== STUDENT VISUAL DNA ===
+{visualDna}
+
+=== EVENTS TO VERIFY ===
+{eventsJsonArray}
+
+For each event, examine the video at the specified timestamp range. Verify the
+actor attribution against the Visual DNA. Return the complete event list with
+any corrections applied.
+
+If an event's actor was wrong, swap it. If a position was misidentified, correct it.
+If you cannot verify with confidence (camera angle, athletes obscured), set confidence to 0.3 or lower.
+```
+
+**Output:** Corrected event list (same schema as Phase 2 output). Persisted to `match_events` table.
+
+**Model Settings:**
+```json
+{
+  "model": "gemini-3.1-pro-preview",
+  "temperature": 0.1,
+  "max_output_tokens": 65535,
+  "thinking_config": { "thinking_budget": 4096 }
+}
+```
+
+### 6.5 Phase 4 — Head Coach (Video-Aware Synthesis)
+
+**Purpose:** Produce high-level coaching output: match summary, key strengths, critical weaknesses, prescribed drills, technical grade, and the "1% Detail" elite insight.
+
+**Key change from v1:** The Head Coach now receives the **cached video + enriched verified events**, not just a text-based Master Match Log. This means the coach can reference specific visual moments in its feedback and provide more accurate timestamp-linked coaching.
+
+**Model:** Configurable, default `gemini-3.1-pro-preview`
+
+**Input:**
+- Cached video via `request.CachedContent = cacheName`
+- Verified events JSON from Phase 3
+- User profile data (belt level, experience, training frequency)
+
+**System Instruction:**
+```
+You are an expert Brazilian Jiu-Jitsu Head Coach and IBJJF Black Belt competitor.
+You have access to both the match video and a structured event log verified for
+accuracy. Analyze the student's performance and produce actionable coaching feedback.
+
+Prioritize score-losing technical errors. Reference specific moments in the video
+when citing strengths and weaknesses. Your feedback should be specific enough that
+the student can rewatch the exact moment you're referencing.
+```
+
+**Prompt template:**
+```
+Review your student's BJJ match. You have both the video and the verified event log below.
+
+=== VERIFIED EVENT LOG ===
+{verifiedEventsJson}
+
+=== STUDENT PROFILE ===
+Belt level: {userBeltLevel}
+Experience: {userExperienceLevel}
+Stamina: {userStaminaMinutes} minutes
+Primary goal: {userPrimaryGoal}
+Height: {userHeight} meter
+Weight: {userWeight} kilogram
+
+=== INSTRUCTIONS ===
+Analyze their overall performance and return structured coaching feedback:
+
+1. match_summary: A narrative paragraph summarizing the match flow and outcome.
+2. key_strengths (max 3): Specific things done well, with video timestamps (ms).
+3. critical_weaknesses (max 3): Specific errors with video timestamp ranges (ms),
+   severity level, and IBJJF scoring impact where applicable.
+4. prescribed_drills (exactly 3): Targeted positional sparring drills for the weaknesses.
+5. technical_grade: 0–100 score reflecting overall technical execution.
+6. grade_label: One-line descriptor (e.g., "Solid Fundamentals", "Raw but Aggressive").
+7. elite_tip: ONE highly specific "1% detail" a black belt would notice. Single sentence.
+
+Use millisecond timestamps for all time references so the mobile app can seek directly
+to the referenced moment.
+```
+
+**Enriched Coaching Report Schema:**
+
+| Field (Weakness) | Change vs v1 | Rationale |
+|------------------|-------------|-----------|
+| `timestamp_start_ms` | **NEW** (replaces free-text `timestamp_reference`) | Structured timestamp for video seeking in annotator portal and mobile app |
+| `timestamp_end_ms` | **NEW** | End of the problematic sequence |
+| `severity` | **NEW** enum: `Critical`, `Major`, `Minor` | Prioritization for HITL review + coaching emphasis |
+| `scoring_impact` | **NEW** (nullable string) | IBJJF scoring context e.g. "2 points lost — guard pass conceded" |
+
+| Field (Strength) | Change vs v1 | Rationale |
+|------------------|-------------|-----------|
+| `timestamp_start_ms` | **NEW** | Structured timestamp so the annotator portal can link to video moment |
+| `timestamp_end_ms` | **NEW** | End of the highlighted sequence |
+
+**Structured Output Schema:**
+```json
+{
+  "type": "object",
+  "required": ["match_summary", "key_strengths", "critical_weaknesses", "prescribed_drills", "technical_grade", "grade_label", "elite_tip"],
+  "properties": {
+    "match_summary": { "type": "string" },
+    "technical_grade": { "type": "number", "minimum": 0, "maximum": 100 },
+    "grade_label": { "type": "string" },
+    "elite_tip": { "type": "string" },
+    "key_strengths": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["title", "explanation", "timestamp_start_ms", "timestamp_end_ms"],
+        "properties": {
+          "title": { "type": "string" },
+          "explanation": { "type": "string" },
+          "timestamp_start_ms": { "type": "integer", "description": "Start of the highlighted moment in absolute video ms" },
+          "timestamp_end_ms": { "type": "integer", "description": "End of the highlighted moment in absolute video ms" }
+        }
+      }
+    },
+    "critical_weaknesses": {
+      "type": "array",
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["title", "explanation", "timestamp_start_ms", "timestamp_end_ms", "severity"],
+        "properties": {
+          "title": { "type": "string" },
+          "explanation": { "type": "string" },
+          "timestamp_start_ms": { "type": "integer", "description": "Start of the problematic sequence in absolute video ms" },
+          "timestamp_end_ms": { "type": "integer", "description": "End of the problematic sequence in absolute video ms" },
+          "severity": { "type": "string", "enum": ["Critical", "Major", "Minor"] },
+          "scoring_impact": {
+            "type": "string",
+            "nullable": true,
+            "description": "IBJJF scoring context, e.g. '2 points lost — guard pass conceded'. Null if not applicable."
+          }
+        }
+      }
+    },
+    "prescribed_drills": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["drill_name", "instructions", "goal"],
+        "properties": {
+          "drill_name": { "type": "string" },
+          "instructions": { "type": "string" },
+          "goal": { "type": "string" }
+        }
+      }
+    }
+  }
+}
+```
+
+**Model Settings:**
+```json
+{
+  "model": "gemini-3.1-pro-preview",
+  "temperature": 0.4,
+  "max_output_tokens": 8192,
+  "thinking_config": { "thinking_budget": 16384 }
+}
+```
+
+### 6.6 Context Cache Lifecycle
+
+The context cache is the backbone of v2's cost efficiency. It stores the video once and allows all phases to reference it without re-uploading.
+
+**Creation:** Phase 1, via `GenAiCacheServiceClient.CreateCachedContentAsync()`.
+
+**TTL:** Configurable (default 30 minutes). Must exceed the expected total pipeline duration. For a 20-minute video, the pipeline typically completes in 2-5 minutes, so 30 minutes provides ample margin.
+
+**Deletion:** Explicitly deleted after Phase 4 completes, or on pipeline failure in a `finally` block:
+
+```csharp
+// Pseudocode: Pipeline execution with cache cleanup
+string? cacheName = null;
+try
+{
+    // Phase 1: creates cache, returns cacheName
+    (cacheName, var visualDna) = await RunAutoProfiler(analysis, config);
+
+    // Phase 2: uses cache
+    var rawEvents = await RunEventLogger(analysis, cacheName, visualDna, config);
+
+    // Phase 3: uses cache
+    var verifiedEvents = await RunEventVerifier(analysis, cacheName, visualDna, rawEvents, config);
+
+    // Phase 4: uses cache
+    var report = await RunHeadCoach(analysis, cacheName, verifiedEvents, config);
+
+    await PersistResults(analysis, verifiedEvents, report);
+    analysis.Status = AnalysisStatus.Complete;
+}
+catch (Exception ex)
+{
+    analysis.Status = AnalysisStatus.Failed;
+    analysis.FailureReason = ex.Message;
+    throw;
+}
+finally
+{
+    if (cacheName != null)
+    {
+        await cacheServiceClient.DeleteCachedContentAsync(cacheName);
+    }
+}
+```
+
+**Cache expiry mid-pipeline:** If the cache TTL expires while a phase is in progress, the Vertex AI API returns an error. The pipeline should catch this as a retryable `ContextCacheExpiredException` and surface a user-friendly failure message. Consider increasing TTL for longer videos.
+
+**Cost:** Gemini context caching costs ~$1.00-$4.50 per million tokens per hour, prorated to the minute. For a typical 10-minute video (~600K tokens at 3 FPS), the cache cost for a 30-minute TTL is approximately $0.30-$1.35. The savings from not re-uploading the video for phases 2-4 far exceed this cost (~90% reduction in input tokens billed).
+
+### 6.7 Agent Model Selection Reference
+
+| Agent | Phase | Model (default) | Thinking Budget | FPS | Why |
+|---|---|---|---|---|---|
+| Auto-Profiler | 1 | `gemini-3.1-pro-preview` | 8192 tokens | 1 | Visual precision for athlete identification; also creates the context cache |
+| Event Logger | 2 | `gemini-3.1-pro-preview` | 16384 tokens | 3-5 | Full-video analysis requires strong reasoning; higher FPS catches fast scrambles |
+| Event Verifier | 3 | `gemini-3.1-pro-preview` | 4096 tokens | N/A (seeks to timestamps) | verification pass — corrects, doesn't generate |
+| Head Coach | 4 | `gemini-3.1-pro-preview` | 16384 tokens | N/A (uses cached video) | Synthesis + video-aware coaching requires Pro-level reasoning |
+
+### 6.8 Configuration Reference
+
+All pipeline parameters are configurable via `appsettings.json` under the `VertexAi:Pipeline` section. This allows model IDs, FPS rates, and cost parameters to be tuned without code changes.
+
+```json
+{
+  "VertexAi": {
+    "ProjectId": "mycoach-app",
+    "Location": "us-central1",
+    "Pipeline": {
+      "ContextCacheTtlMinutes": 30,
+      "ConfidenceThresholdForReview": 0.7,
+      "Phase1_AutoProfiler": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Fps": 1,
+        "Temperature": 0.1,
+        "MaxOutputTokens": 1024,
+        "ThinkingBudget": 8192
+      },
+      "Phase2_EventLogger": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Fps": 3,
+        "Temperature": 0.2,
+        "MaxOutputTokens": 65535,
+        "ThinkingBudget": 16384
+      },
+      "Phase3_EventVerifier": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Fps": 0,
+        "Temperature": 0.1,
+        "MaxOutputTokens": 65535,
+        "ThinkingBudget": 4096
+      },
+      "Phase4_HeadCoach": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Fps": 0,
+        "Temperature": 0.4,
+        "MaxOutputTokens": 8192,
+        "ThinkingBudget": 16384
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+- `ModelId`: Use GA (generally available) models for production. Preview models (e.g., `gemini-3.1-pro-preview-preview`) may be used for experimentation but have no SLA.
+- `Fps`: Set to 0 for phases that don't perform frame-by-frame analysis (Phases 3 and 4 seek to specific timestamps or rely on the cached video).
+- `ConfidenceThresholdForReview`: Events with `confidence` below this value are candidates for HITL review in the future annotation portal.
+- `ThinkingBudget`: Number of thinking tokens allocated. Higher values enable deeper reasoning but increase latency and cost.
+
+### 6.9 Fallback: Long Video Chunking
+
+For videos exceeding 30 minutes (above our current 20-minute MVP limit), the old chunking strategy MAY be re-enabled as a fallback. This is gated on `VideoDurationSecs > 1800`.
+
+**This is NOT implemented in MVP.** Document as a future consideration:
+- If Gemini's context window or context caching limits are reached for very long videos, the pipeline can fall back to chunking
+- The chunking service code (`VideoChunkingService`) is retained but not invoked in the v2 pipeline
+- If re-enabled, it would insert between Phase 1 and Phase 2, with Phase 2 running per-chunk and Phase 3 verifying cross-chunk identity consistency
+- Requires re-adding `chunk_index` to the schema and implementing a merge step
+
+---
+
+## 7. Video Upload Flow (GCS Integration)
+
+### 7.1 Local Upload (Device File)
+
+```
+Mobile Client                       .NET API                     GCS
+     │                                  │                          │
+     │── POST /analyses/upload-url ─────►│                          │
+     │   { fileName, fileSize, mimeType }│                          │
+     │                                  │── GenerateSignedUrl() ──►│
+     │                                  │◄── signedUploadUrl ───── │
+     │◄── 200 { analysisId, uploadUrl } ─│                          │
+     │                                  │                          │
+     │── PUT {uploadUrl} (video bytes) ─────────────────────────── ►│
+     │◄── 200 OK ──────────────────────────────────────────────── ─│
+     │                                  │                          │
+     │── POST /analyses ────────────────►│                          │
+     │   { analysisId, sourceType:       │                          │
+     │     'local_upload',               │── Enqueue pipeline job   │
+     │     studentIdentifier }           │                          │
+     │◄── 202 Accepted { analysisId } ──│                          │
+```
+
+- Signed URL expiry: **15 minutes**.
+- GCS path: `videos/{userId}/{analysisId}/raw.{ext}`
+- Accepted MIME types: `video/mp4`, `video/quicktime`.
+- Max file size enforced at signed URL generation: **2GB** (MVP limit).
+
+### 7.2 URL Paste (Instagram / TikTok / YouTube) (IGNORE THIS FEATURE FOR MVP, IT'S NOT REQUIRED FOR MVP!!!!!!)
+
+- The `.NET API` receives the URL from the mobile client.
+- The API uses a server-side HTTP client to attempt a direct video stream download (using RapidAPI scraping service).
+- If direct download fails (private/auth-gated), the analysis fails with a clear error: `{ error: "VIDEO_UNAVAILABLE", message: "This link requires login or is private." }`.
+- Once downloaded, the video is uploaded to GCS under the same path convention.
+
+---
+
+## 8. Pipeline Execution Strategy
+
+### 8.1 Async Execution (MVP Approach)
+
+The analysis pipeline is long-running (estimated 30–120 seconds for a full match). It must not block the HTTP request thread.
+
+**MVP implementation:** Use .NET `IHostedService` with a simple in-memory queue (backed by `Channel<T>`). After `POST /analyses` is received, the job is enqueued and a `202 Accepted` is returned immediately. The mobile client polls `GET /analyses/{id}/status` every 3 seconds.
+
+**Status transitions (Pipeline v2):**
+```
+pending → uploading → profiling → logging → verifying → coaching → complete
+                                                                    ↘ failed
+```
+
+> **v2 change:** Removed `chunking` and `merging` statuses (no longer applicable). Added `verifying` for the new Phase 3 identity verification pass.
+
+Each transition updates `analyses.status` in PostgreSQL. The `progressLabel` field returned by the status endpoint maps to the mobile client's loading screen messages.
+
+| DB Status | Mobile Label |
+|---|---|
+| `uploading` | "Uploading footage..." |
+| `profiling` | "Identifying your athlete..." |
+| `logging` | "Analyzing positions & transitions..." |
+| `verifying` | "Verifying identity tracking..." |
+| `coaching` | "Crafting your coach notes..." |
+| `complete` | *(Navigate to Dashboard)* |
+| `failed` | "Analysis failed — please try again." |
+
+### 8.2 Error Handling
+
+- If any Phase fails, set `analyses.status = 'failed'` with an error message stored in a `failure_reason` column.
+- Partial results (e.g., Phase III completed but Phase V failed) should be retained in the database for debugging.
+- The mobile client displays a retry CTA on failure. Retry re-uses the existing `analysisId` and GCS video — no re-upload required.
+
+---
+
+## 9. GCS Bucket Structure
+
+```
+mycoach-videos/
+├── videos/
+│   └── {userId}/
+│       └── {analysisId}/
+│           ├── raw.mp4              ← original upload
+│           └── thumbnail.jpg        ← server-extracted frame
+└── temp/
+    └── {analysisId}/
+        ├── chunk_0.mp4
+        ├── chunk_1.mp4
+        └── chunk_n.mp4              ← deleted after pipeline completes
+```
+
+- **Lifecycle policy:** `temp/` objects auto-deleted after 24 hours (GCS Object Lifecycle rule).
+- **Access:** All read access via signed URLs (time-limited). No public bucket access.
+- **Thumbnails:** Extracted server-side using `FFMpegCore` from the 5-second mark of the raw video.
+
+---
+
+## 10. Non-Functional Requirements
+
+| Requirement | Target |
+|---|---|
+| **API Response Time (non-pipeline)** | P95 < 300ms |
+| **Pipeline Processing Time (P90)** | ≤ 90 seconds for a 5-minute match |
+| **API Availability** | ≥ 99.5% (Cloud Run SLA) |
+| **Max Concurrent Pipeline Jobs (MVP)** | 5 (limited by Vertex AI quota on free/dev tier) |
+| **Database Connection Pool** | Max 10 connections (Supabase free tier limit) |
+| **Video Upload Size Limit** | 2GB |
+| **Auth Token Verification** | Every request — no exceptions |
+| **Log Retention** | 30 days (Cloud Logging) |
+
+---
+
+## 11. Out of Scope (Backend MVP)
+
+| Feature | Future Phase |
+|---|---|
+| Web Annotator Portal API | Post-MVP — after mobile launch and pipeline validation |
+| VLM Fine-tuning / Feedback Data Pipeline | Post-MVP — requires annotator portal and Golden Dataset |
+| Real-time streaming (WebSockets / SSE) | Post-MVP — polling sufficient for MVP |
+| RapidAPI / social media scraper integration | Post-MVP — validate direct upload loop first |
+| Push notifications (FCM) | Post-MVP — for async job completion alerts |
+| Multi-athlete tracking (team accounts) | Post-MVP |
+| Rate limiting / abuse protection | Post-MVP — add before public launch |
+
+---
+
+## 12. Post-MVP: Human-in-the-Loop (HITL) Annotation Layer
+
+> A separate PRD will be written for the Annotator Portal when the time comes. This section documents the schema design philosophy and future data model so that the VLM pipeline output (Section 6) is structured to support HITL from day one.
+
+After the mobile MVP is live and the agentic pipeline is producing real-world results, the next phase will introduce a **BJJ Expert Annotator Web Portal** to review, correct, and approve VLM outputs — closing the loop between production AI and continuous model improvement.
+
+### 12.1 Schema Design Philosophy
+
+The enriched schemas in Pipeline v2 (Section 6) are designed with HITL in mind:
+
+- **VLM populates all fields; annotators review/correct, not create from scratch.** Every event comes pre-filled with technique category, positions, outcome, and confidence. The annotator's job is to verify and fix, not to label from a blank slate. This dramatically reduces annotation time per event.
+
+- **`confidence` enables auto-triage.** Events with confidence below the configurable threshold (`ConfidenceThresholdForReview`, default 0.7) are automatically queued for expert review. High-confidence events can be auto-approved, focusing human effort where it matters most.
+
+- **`technique_name` (free-text) captures the VLM's specific guess.** Rather than forcing the VLM to select from a closed taxonomy (which would limit it to techniques it was explicitly trained on), the free-text field captures whatever the model identifies (e.g., "Berimbolo back take", "Darce choke attempt"). A standardized technique taxonomy is built iteratively from annotated data over time, not imposed upfront.
+
+- **`position_before` + `position_after` enable flow analysis.** Annotators can verify not just what happened, but the positional context — enabling future training data that teaches the model about position transitions, not just isolated techniques.
+
+- **Structured timestamps (`timestamp_start_ms`, `timestamp_end_ms`) enable video-linked review.** The annotator portal can seek directly to the relevant video moment, compare the VLM output with what they see, and correct inline.
+
+### 12.2 Future Annotation Data Model
+
+The following fields will be added to `match_events` and `coaching_reports` when the annotator portal is built. They are **NOT added to the database now** — they are documented here so the pipeline v2 schema is forward-compatible.
+
+**MatchEvent annotation fields (future):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `review_status` | string (enum) | `pending_review`, `approved`, `corrected`, `rejected`. Default: `pending_review` for events below confidence threshold, `approved` for events above. |
+| `reviewed_by` | UUID (FK) | → annotator_users(id). The expert who reviewed this event. |
+| `reviewed_at` | timestamptz | When the review was completed. |
+| `original_vlm_output` | jsonb | Snapshot of the VLM output before any corrections. Preserved for training data export. |
+| `correction_notes` | text | Annotator explanation of what was wrong and why (e.g., "Camera angle made it look like Student but it was Opponent initiating the sweep"). |
+
+**CoachingReport annotation fields (future):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `review_status` | string (enum) | `pending_review`, `approved`, `corrected`. |
+| `reviewed_by` | UUID (FK) | → annotator_users(id) |
+| `reviewed_at` | timestamptz | When the review was completed. |
+| `original_vlm_output` | jsonb | Snapshot of original coaching report before corrections. |
+
+**Review status enum:**
+- `pending_review` — Awaiting expert review (auto-set for low-confidence events)
+- `approved` — Expert confirmed VLM output is correct
+- `corrected` — Expert modified one or more fields
+- `rejected` — Event is invalid (e.g., VLM hallucinated an event that didn't happen)
+
+### 12.3 Fine-Tuning Data Export
+
+Corrected events paired with their original VLM outputs form supervised fine-tuning training pairs:
+
+- **Input:** Video segment (referenced by timestamp range) + prompt template
+- **Expected output:** The corrected structured JSON (what the model should have produced)
+- **Export format:** JSONL for Vertex AI supervised fine-tuning API
+
+```jsonl
+{"input": {"video_uri": "gs://...", "start_ms": 45000, "end_ms": 52000, "prompt": "..."}, "output": {"actor": "Student", "technique_category": "Sweep", "technique_name": "Scissor Sweep", "position_before": "ClosedGuard", "position_after": "Mount", "outcome": "Successful", "confidence": 1.0}}
+{"input": {"video_uri": "gs://...", "start_ms": 120000, "end_ms": 128000, "prompt": "..."}, "output": {"actor": "Opponent", "technique_category": "Pass", "technique_name": "Knee Slice Pass", "position_before": "HalfGuard", "position_after": "SideControl", "outcome": "Successful", "confidence": 1.0}}
+```
+
+**Data pipeline (future):**
+1. Export all `corrected` and `approved` events with their `original_vlm_output` snapshots
+2. Generate prompt + video segment pairs
+3. Upload to Vertex AI as a supervised fine-tuning dataset
+4. Fine-tune the Event Logger model (Phase 2) to reduce identity drift and improve technique classification
+5. Evaluate fine-tuned model against a held-out Golden Dataset before promoting to production

--- a/docs/VertexAiService.cs
+++ b/docs/VertexAiService.cs
@@ -1,0 +1,715 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MyCoach.Application.Exceptions;
+using MyCoach.Application.Interfaces;
+using MyCoach.Application.Pipeline.Models;
+
+namespace MyCoach.Infrastructure.AI;
+
+public class VertexAiService : IVertexAiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly GoogleCredential _credential;
+    private readonly string _projectId;
+    private readonly IConfiguration _config;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<VertexAiService> _logger;
+
+    public VertexAiService(HttpClient httpClient, IConfiguration configuration, TimeProvider timeProvider, ILogger<VertexAiService> logger)
+    {
+        _httpClient = httpClient;
+        _projectId = configuration["VertexAi:ProjectId"]
+            ?? throw new InvalidOperationException("VertexAi:ProjectId is not configured.");
+        _credential = GoogleCredential.GetApplicationDefault();
+        _config = configuration;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    private async Task<string> GetAccessTokenAsync()
+    {
+        var tokenAccess = _credential as ITokenAccess;
+        return await tokenAccess!.GetAccessTokenForRequestAsync();
+    }
+
+    private string PipelineConfig(string key, string defaultValue) =>
+        _config[$"VertexAi:Pipeline:{key}"] ?? defaultValue;
+
+    private float PipelineConfigFloat(string key, float defaultValue) =>
+        float.TryParse(_config[$"VertexAi:Pipeline:{key}"], out var val) ? val : defaultValue;
+
+    private int PipelineConfigInt(string key, int defaultValue) =>
+        int.TryParse(_config[$"VertexAi:Pipeline:{key}"], out var val) ? val : defaultValue;
+
+    private int CacheTtlMinutes =>
+        int.TryParse(_config["VertexAi:Pipeline:ContextCacheTtlMinutes"], out var ttl) ? ttl : 30;
+
+    private string ModelPath(string modelId) =>
+        $"projects/{_projectId}/locations/global/publishers/google/models/{modelId}";
+
+    private string GenerateContentUrl(string modelId) =>
+        $"/v1/{ModelPath(modelId)}:generateContent";
+
+    private string CreateCacheUrl() =>
+        $"/v1/projects/{_projectId}/locations/global/cachedContents";
+
+    private string DeleteCacheUrl(string cacheName) =>
+        $"/v1/{cacheName}";
+
+    // ── Phase 1: Auto-Profiler + Context Cache Creation ─────────────────
+
+    public async Task<(string CacheName, string VisualDna)> CreateCacheAndGenerateVisualDnaAsync(
+        string videoGcsUri,
+        string studentIdentifier,
+        CancellationToken ct)
+    {
+        _logger.LogInformation("Phase 1: Creating context cache for {VideoUri}", videoGcsUri);
+
+        var modelId = PipelineConfig("Phase1_AutoProfiler:ModelId", "gemini-3.1-pro-preview");
+        var expireTime = _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(CacheTtlMinutes);
+
+        var cacheBody = new
+        {
+            model = ModelPath(modelId),
+            displayName = $"mycoach-pipeline-{Guid.NewGuid():N}",
+            expireTime = expireTime.ToString("O"),
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[]
+                    {
+                        new { fileData = new { mimeType = "video/mp4", fileUri = videoGcsUri } }
+                    }
+                }
+            }
+        };
+
+        var cacheResponse = await PostJsonAsync(CreateCacheUrl(), cacheBody, ct);
+        var cacheName = cacheResponse.GetProperty("name").GetString()
+            ?? throw new InvalidOperationException("Cache creation response missing 'name' field.");
+
+        _logger.LogInformation("Phase 1: Cache created: {CacheName}, TTL: {Ttl}m", cacheName, CacheTtlMinutes);
+
+        var phase1Prompt = $"""
+            You are a Forensic Video Analyst specializing in combat sports footage.
+            Watch the opening segment of this video. Locate the athlete matching this description:
+            '{studentIdentifier}'.
+
+            Generate a hyper-detailed, immutable 'Visual DNA' profile of this specific athlete.
+            Include ALL of the following when visible:
+            - Gi/rashguard: color, brand, sleeve length, any distinguishing wear/damage
+            - Belt: color, stripe count, knot style
+            - Physical: hair color/style, skin tone, body type, approximate height relative to opponent
+            - Distinguishing marks: visible team patches and their locations, sponsor logos,
+              ankle supports, knee braces, athletic tape on fingers or joints, ear guards
+            - Movement signature: dominant stance (orthodox/southpaw), posture tendency
+
+            Return ONLY a single descriptive paragraph. No bullet points. No headers. No analysis.
+            """;
+
+        var request = new
+        {
+            cachedContent = cacheName,
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[] { new { text = phase1Prompt } }
+                }
+            },
+            generationConfig = new
+            {
+                temperature = PipelineConfigFloat("Phase1_AutoProfiler:Temperature", 0.1f),
+                maxOutputTokens = 1024,
+                thinkingConfig = new { thinkingBudget = PipelineConfigInt("Phase1_AutoProfiler:ThinkingBudgetTokens", 8192) }
+            }
+        };
+
+        var response = await PostJsonAsync(GenerateContentUrl(modelId), request, ct);
+        var visualDna = ExtractText(response);
+
+        _logger.LogInformation("Phase 1 complete. Visual DNA ({Length} chars): {Preview}",
+            visualDna.Length, visualDna[..Math.Min(200, visualDna.Length)]);
+        return (cacheName, visualDna);
+    }
+
+    // ── Phase 2: Event Logger (full video) ──────────────────────────────
+
+    public async Task<List<RawMatchEvent>> LogEventsAsync(
+        string cacheName,
+        string visualDna,
+        CancellationToken ct)
+    {
+        _logger.LogInformation("Phase 2: Logging events from full video");
+
+        var modelId = PipelineConfig("Phase2_EventLogger:ModelId", "gemini-3.1-pro-preview");
+        var thinkingBudget = PipelineConfigInt("Phase2_EventLogger:ThinkingBudgetTokens", 16384);
+
+        var events = await RunEventLoggerAsync(cacheName, visualDna, modelId, thinkingBudget, BuildPrimaryEventLoggerPrompt(visualDna), ct);
+
+        if (events.Count == 0)
+        {
+            _logger.LogWarning("Phase 2: Primary prompt returned 0 events — retrying with simplified prompt");
+            events = await RunEventLoggerAsync(cacheName, visualDna, modelId, thinkingBudget, BuildFallbackEventLoggerPrompt(), ct);
+            _logger.LogInformation("Phase 2 fallback: {Count} events logged", events.Count);
+        }
+
+        _logger.LogInformation("Phase 2 complete: {Count} events logged", events.Count);
+        return events;
+    }
+
+    private string BuildPrimaryEventLoggerPrompt(string visualDna)
+    {
+        var fpsRate = PipelineConfigInt("Phase2_EventLogger:FpsRate", 3);
+
+        return $"""
+            You are a meticulous grappling play-by-play logger and an expert BJJ black belt instructor.
+            Watch this complete BJJ match video from start to finish and log every significant action.
+
+            STUDENT IDENTIFICATION:
+            The student athlete matches this visual profile:
+            {visualDna}
+            Every 30 seconds of video, re-confirm which athlete is the student. If uncertain,
+            set confidence to 0.3 or lower for those events.
+
+            WHAT TO LOG:
+            - Every positional change (e.g., standing to guard, guard to mount)
+            - Every technique attempt — successful or failed (takedowns, sweeps, passes, submissions, escapes)
+            - Every transition and scramble
+            - Actions by BOTH the student and their opponent
+            You MUST log at least one event for every 30 seconds of video. A typical 2-minute match
+            should produce 8-20 events minimum.
+
+            HOW TO LOG:
+            - Use absolute video timestamps in milliseconds from the start of the video
+            - Attribute each action to "Student" or "Opponent" based on the visual profile above
+            - Assess your confidence (0.0 to 1.0) as the minimum of: actor attribution accuracy,
+              technique classification accuracy, and position identification accuracy
+            - Analyze at a minimum of {fpsRate} frames per second — do not skip frames during scrambles
+
+            IMPORTANT: You must return a JSON object with an "events" array. The array must NOT be empty.
+            Even if the video is unclear, log what you can observe with lower confidence scores.
+            """;
+    }
+
+    private static string BuildFallbackEventLoggerPrompt() => """
+        Watch this BJJ match video and describe every action you see, in order.
+
+        For each action, provide:
+        - When it happens (start and end timestamps in milliseconds)
+        - Who does it: "Student" (the person who was identified in the previous analysis) or "Opponent"
+        - What type of action it is (e.g., Takedown, Pass, Sweep, Submission, Escape, Transition, Control)
+        - What specific technique is used (e.g., Double Leg, Armbar, Knee Slice)
+        - What position they were in before and after the action
+        - Whether it was successful, failed, or partial
+        - A brief description of what happened
+        - How confident you are (0.0 to 1.0)
+
+        You MUST return at least one event. Describe everything you can observe in the video.
+        """;
+
+    private async Task<List<RawMatchEvent>> RunEventLoggerAsync(
+        string cacheName,
+        string visualDna,
+        string modelId,
+        int thinkingBudget,
+        string prompt,
+        CancellationToken ct)
+    {
+        var request = new
+        {
+            cachedContent = cacheName,
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[] { new { text = prompt } }
+                }
+            },
+            generationConfig = new
+            {
+                temperature = PipelineConfigFloat("Phase2_EventLogger:Temperature", 0.2f),
+                maxOutputTokens = 65535,
+                topP = 1.0f,
+                responseMimeType = "application/json",
+                responseSchema = BuildEventLoggerSchema(),
+                thinkingConfig = new { thinkingBudget }
+            }
+        };
+
+        JsonElement response;
+        try
+        {
+            response = await PostJsonAsync(GenerateContentUrl(modelId), request, ct);
+        }
+        catch (HttpRequestException ex) when (IsCacheExpired(ex))
+        {
+            throw new ContextCacheExpiredException(cacheName);
+        }
+
+        var json = ExtractText(response);
+
+        _logger.LogInformation("Phase 2 raw response ({Length} chars): {Preview}",
+            json.Length, json[..Math.Min(500, json.Length)]);
+
+        var parsed = JsonSerializer.Deserialize<EventLoggerResponse>(json, JsonOptions);
+        return parsed?.Events ?? [];
+    }
+
+    // ── Phase 3: Event Verifier ─────────────────────────────────────────
+
+    public async Task<List<RawMatchEvent>> VerifyEventsAsync(
+        string cacheName,
+        string visualDna,
+        List<RawMatchEvent> events,
+        CancellationToken ct)
+    {
+        _logger.LogInformation("Phase 3: Verifying {Count} events", events.Count);
+
+        // Must match the cache model (Phase 1) — Vertex AI requires cached content
+        // model to match inference model. Cannot use flash-lite with a pro cache.
+        var modelId = PipelineConfig("Phase3_EventVerifier:ModelId", "gemini-3.1-pro-preview");
+        var thinkingBudget = PipelineConfigInt("Phase3_EventVerifier:ThinkingBudgetTokens", 4096);
+        var eventsJson = JsonSerializer.Serialize(new { events }, JsonOptions);
+
+        var prompt = $"""
+            You are a BJJ match identity verification specialist. You have a list of timestamped
+            events from a BJJ match and the Visual DNA profile of the student athlete.
+
+            For each event, examine the video at the specified timestamp and verify:
+            1. Is the "actor" field correct? Does the person performing this action match the Visual DNA?
+            2. Are "position_before" and "position_after" accurate for what you see?
+            3. Is the "technique_category" correct?
+
+            You may CORRECT any field you find inaccurate. LOWER the confidence score for any
+            event where verification is ambiguous (camera angle, athletes obscured).
+            If an actor was wrong, swap it. If a position was misidentified, correct it.
+
+            Do NOT add new events. Do NOT remove events. Only correct existing ones.
+
+            STUDENT VISUAL DNA:
+            {visualDna}
+
+            EVENTS TO VERIFY:
+            {eventsJson}
+
+            Return the complete event list with any corrections applied.
+            """;
+
+        var request = new
+        {
+            cachedContent = cacheName,
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[] { new { text = prompt } }
+                }
+            },
+            generationConfig = new
+            {
+                temperature = PipelineConfigFloat("Phase3_EventVerifier:Temperature", 0.1f),
+                maxOutputTokens = 65535,
+                responseMimeType = "application/json",
+                responseSchema = BuildEventLoggerSchema(),
+                thinkingConfig = new { thinkingBudget }
+            }
+        };
+
+        JsonElement response;
+        try
+        {
+            response = await PostJsonAsync(GenerateContentUrl(modelId), request, ct);
+        }
+        catch (HttpRequestException ex) when (IsCacheExpired(ex))
+        {
+            throw new ContextCacheExpiredException(cacheName);
+        }
+
+        var json = ExtractText(response);
+
+        _logger.LogInformation("Phase 3 raw response ({Length} chars): {Preview}",
+            json.Length, json[..Math.Min(300, json.Length)]);
+
+        var parsed = JsonSerializer.Deserialize<EventLoggerResponse>(json, JsonOptions);
+        var verified = parsed?.Events ?? events;
+
+        _logger.LogInformation("Phase 3 complete: {Count} events verified", verified.Count);
+        return verified;
+    }
+
+    // ── Phase 4: Head Coach (video-aware) ───────────────────────────────
+
+    public async Task<CoachingResult> GenerateCoachingReportAsync(
+        string cacheName,
+        string verifiedEventsJson,
+        string? beltLevel,
+        string? experienceLevel,
+        string? primaryGoal,
+        int? staminaMinutes,
+        decimal? heightCm,
+        decimal? weightKg,
+        CancellationToken ct)
+    {
+        _logger.LogInformation("Phase 4: Generating coaching report");
+
+        var modelId = PipelineConfig("Phase4_HeadCoach:ModelId", "gemini-3.1-pro-preview");
+        var thinkingBudget = PipelineConfigInt("Phase4_HeadCoach:ThinkingBudgetTokens", 16384);
+
+        var heightMeters = heightCm.HasValue ? $"{heightCm.Value / 100m:F2}" : "unknown";
+        var weightStr = weightKg.HasValue ? $"{weightKg.Value:F1}" : "unknown";
+
+        var studentProfile = $"""
+            Belt level: {beltLevel ?? "unknown"}
+            Experience: {experienceLevel ?? "unknown"}
+            Stamina: {staminaMinutes?.ToString() ?? "unknown"} minutes
+            Primary goal: {primaryGoal ?? "not specified"}
+            Height: {heightMeters} meter
+            Weight: {weightStr} kilogram
+            """;
+
+        var phase4Prompt = $"""
+            You are an expert Brazilian Jiu-Jitsu Head Coach and IBJJF Black Belt competitor.
+            You have access to both the match video and a structured event log verified for accuracy.
+
+            Review your student's BJJ match and produce actionable coaching feedback.
+            Prioritize score-losing technical errors. Reference specific moments in the video
+            using millisecond timestamps so the mobile app can seek directly to them.
+
+            VERIFIED EVENT LOG:
+            {verifiedEventsJson}
+
+            STUDENT PROFILE:
+            {studentProfile}
+
+            Return structured coaching feedback with:
+            1. match_summary: A narrative paragraph summarizing the match flow and outcome.
+            2. key_strengths (max 3): Specific things done well, with video timestamps (ms).
+            3. critical_weaknesses (max 3): Specific errors with video timestamp ranges (ms),
+               severity level (Critical/Major/Minor), and IBJJF scoring impact where applicable.
+            4. prescribed_drills (exactly 3): Targeted positional sparring drills for the weaknesses.
+            5. technical_grade: 0-100 score reflecting overall technical execution.
+            6. grade_label: One-line descriptor (e.g., "Solid Fundamentals").
+            7. elite_tip: ONE highly specific "1% detail" a black belt would notice.
+            """;
+
+        var request = new
+        {
+            cachedContent = cacheName,
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new[] { new { text = phase4Prompt } }
+                }
+            },
+            generationConfig = new
+            {
+                temperature = PipelineConfigFloat("Phase4_HeadCoach:Temperature", 0.4f),
+                maxOutputTokens = 8192,
+                responseMimeType = "application/json",
+                responseSchema = BuildCoachingSchema(),
+                thinkingConfig = new { thinkingBudget }
+            }
+        };
+
+        JsonElement response;
+        try
+        {
+            response = await PostJsonAsync(GenerateContentUrl(modelId), request, ct);
+        }
+        catch (HttpRequestException ex) when (IsCacheExpired(ex))
+        {
+            throw new ContextCacheExpiredException(cacheName);
+        }
+
+        var json = ExtractText(response);
+        var parsed = JsonSerializer.Deserialize<CoachingJsonResponse>(json, JsonOptions)
+            ?? throw new InvalidOperationException("Failed to parse coaching report response.");
+
+        _logger.LogInformation("Phase 4 complete. Grade: {Grade} ({Label})", parsed.TechnicalGrade, parsed.GradeLabel);
+
+        return new CoachingResult(
+            parsed.MatchSummary,
+            parsed.TechnicalGrade,
+            parsed.GradeLabel,
+            parsed.EliteTip,
+            parsed.KeyStrengths.Select(s => new CoachingStrength(s.Title, s.Explanation, s.TimestampStartMs, s.TimestampEndMs)).ToList(),
+            parsed.CriticalWeaknesses.Select(w => new CoachingWeakness(w.Title, w.Explanation, w.TimestampStartMs, w.TimestampEndMs, w.Severity, w.ScoringImpact)).ToList(),
+            parsed.PrescribedDrills.Select(d => new CoachingDrill(d.DrillName, d.Instructions, d.Goal)).ToList());
+    }
+
+    // ── Cache Deletion ──────────────────────────────────────────────────
+
+    public async Task DeleteCacheAsync(string cacheName, CancellationToken ct)
+    {
+        _logger.LogInformation("Deleting context cache {CacheName}", cacheName);
+        await DeleteAsync(DeleteCacheUrl(cacheName), ct);
+    }
+
+    // ── Phase 2.8 v2 (ADR-054 §5) — single-shot structured doc extraction ─
+
+    public async Task<string> ExtractStructuredAsync(
+        string gcsUri,
+        string mimeType,
+        string promptText,
+        object responseSchema,
+        CancellationToken ct)
+    {
+        // Use the same fast model the rest of the pipeline uses. No context
+        // cache here — extraction is one-and-done; caching a 1-file payload
+        // for 30 minutes would burn quota with no upside. The thinking budget
+        // is small (4k) because the task is structured-output extraction, not
+        // multi-step reasoning.
+        var modelId = PipelineConfig("DocumentExtractor:ModelId", "gemini-3.1-pro-preview");
+        var thinkingBudget = PipelineConfigInt("DocumentExtractor:ThinkingBudgetTokens", 4096);
+
+        _logger.LogInformation(
+            "Document extraction: model={ModelId} gcsUri={GcsUri} mimeType={MimeType}",
+            modelId, gcsUri, mimeType);
+
+        var request = new
+        {
+            // No cachedContent — direct fileData inline. Vertex AI accepts a
+            // gs:// URI as fileData; ADC service-account auth fetches it.
+            contents = new[]
+            {
+                new
+                {
+                    role = "user",
+                    parts = new object[]
+                    {
+                        new { fileData = new { fileUri = gcsUri, mimeType } },
+                        new { text = promptText },
+                    },
+                },
+            },
+            generationConfig = new
+            {
+                temperature = PipelineConfigFloat("DocumentExtractor:Temperature", 0.0f),
+                maxOutputTokens = 65535,
+                topP = 1.0f,
+                responseMimeType = "application/json",
+                responseSchema,
+                thinkingConfig = new { thinkingBudget },
+            },
+        };
+
+        var response = await PostJsonAsync(GenerateContentUrl(modelId), request, ct);
+        var text = ExtractText(response);
+
+        _logger.LogInformation(
+            "Document extraction response ({Length} chars): {Preview}",
+            text.Length, text[..Math.Min(500, text.Length)]);
+
+        return text;
+    }
+
+    // ── HTTP Helpers ─────────────────────────────────────────────────────
+
+    private async Task<JsonElement> PostJsonAsync(string url, object body, CancellationToken ct)
+    {
+        var token = await GetAccessTokenAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Content = JsonContent.Create(body, options: JsonOptions);
+
+        var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(
+                $"Vertex AI request failed with {(int)response.StatusCode}: {errorBody[..Math.Min(500, errorBody.Length)]}",
+                null,
+                response.StatusCode);
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        return await JsonSerializer.DeserializeAsync<JsonElement>(stream, cancellationToken: ct);
+    }
+
+    private async Task DeleteAsync(string url, CancellationToken ct)
+    {
+        var token = await GetAccessTokenAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Delete, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+            _logger.LogWarning("Cache delete failed with {StatusCode}: {Body}",
+                (int)response.StatusCode, body[..Math.Min(200, body.Length)]);
+        }
+    }
+
+    private static string ExtractText(JsonElement response)
+    {
+        return response
+            .GetProperty("candidates")[0]
+            .GetProperty("content")
+            .GetProperty("parts")[0]
+            .GetProperty("text")
+            .GetString()
+            ?? throw new InvalidOperationException("Response contained no text in candidates[0].content.parts[0].text");
+    }
+
+    private static bool IsCacheExpired(HttpRequestException ex) =>
+        ex.StatusCode == HttpStatusCode.NotFound;
+
+    // ── Schemas ─────────────────────────────────────────────────────────
+
+    private static object BuildEventLoggerSchema() => new
+    {
+        type = "OBJECT",
+        required = new[] { "events" },
+        properties = new
+        {
+            events = new
+            {
+                type = "ARRAY",
+                description = "List of all match events observed in the video, in chronological order",
+                items = new
+                {
+                    type = "OBJECT",
+                    required = new[]
+                    {
+                        "start_timestamp_ms", "end_timestamp_ms", "actor",
+                        "technique_category", "technique_name",
+                        "position_before", "position_after",
+                        "outcome", "actions_description", "confidence"
+                    },
+                    properties = new Dictionary<string, object>
+                    {
+                        ["start_timestamp_ms"] = new { type = "INTEGER", description = "Absolute milliseconds from start of video when this action begins" },
+                        ["end_timestamp_ms"] = new { type = "INTEGER", description = "Absolute milliseconds from start of video when this action ends" },
+                        ["actor"] = new { type = "STRING", description = "Who performs this action", @enum = new[] { "Student", "Opponent" } },
+                        ["technique_category"] = new
+                        {
+                            type = "STRING",
+                            description = "Category of technique. Use one of: Takedown, Submission, Sweep, Pass, Escape, Transition, Control, Defense, GuardPull, Scramble, StandUp, GripFight"
+                        },
+                        ["technique_name"] = new { type = "STRING", description = "Specific technique name, e.g. 'Double Leg', 'Armbar from Guard', 'Knee Slice Pass'" },
+                        ["position_before"] = new
+                        {
+                            type = "STRING",
+                            description = "Position at the start of this action. Use one of: Standing, OpenGuard, ClosedGuard, HalfGuard, SideControl, Mount, BackControl, Turtle, KneeOnBelly, NorthSouth, FiftyFifty, Crucifix, Scramble"
+                        },
+                        ["position_after"] = new
+                        {
+                            type = "STRING",
+                            description = "Position at the end of this action. Use one of: Standing, OpenGuard, ClosedGuard, HalfGuard, SideControl, Mount, BackControl, Turtle, KneeOnBelly, NorthSouth, FiftyFifty, Crucifix, Scramble"
+                        },
+                        ["outcome"] = new
+                        {
+                            type = "STRING",
+                            description = "Result of this action",
+                            @enum = new[] { "Successful", "Failed", "Partial", "Countered", "InProgress" }
+                        },
+                        ["guard_type"] = new { type = "STRING", nullable = true, description = "Specific guard variant if position is a guard (e.g. 'De La Riva', 'Spider', 'Butterfly'). Null when not in guard." },
+                        ["submission_type"] = new { type = "STRING", nullable = true, description = "Specific submission name when technique_category is Submission (e.g. 'Rear Naked Choke', 'Armbar'). Null otherwise." },
+                        ["actions_description"] = new { type = "STRING", description = "Free-text description of what happened during this event" },
+                        ["confidence"] = new { type = "NUMBER", description = "Confidence score 0.0-1.0, the minimum of actor attribution, technique classification, and position identification confidence" }
+                    }
+                }
+            }
+        }
+    };
+
+    private static object BuildCoachingSchema() => new
+    {
+        type = "OBJECT",
+        required = new[] { "match_summary", "key_strengths", "critical_weaknesses", "prescribed_drills", "technical_grade", "grade_label", "elite_tip" },
+        properties = new Dictionary<string, object>
+        {
+            ["match_summary"] = new { type = "STRING" },
+            ["technical_grade"] = new { type = "NUMBER" },
+            ["grade_label"] = new { type = "STRING" },
+            ["elite_tip"] = new { type = "STRING" },
+            ["key_strengths"] = new
+            {
+                type = "ARRAY",
+                items = new
+                {
+                    type = "OBJECT",
+                    required = new[] { "title", "explanation", "timestamp_start_ms", "timestamp_end_ms" },
+                    properties = new Dictionary<string, object>
+                    {
+                        ["title"] = new { type = "STRING" },
+                        ["explanation"] = new { type = "STRING" },
+                        ["timestamp_start_ms"] = new { type = "INTEGER" },
+                        ["timestamp_end_ms"] = new { type = "INTEGER" }
+                    }
+                }
+            },
+            ["critical_weaknesses"] = new
+            {
+                type = "ARRAY",
+                items = new
+                {
+                    type = "OBJECT",
+                    required = new[] { "title", "explanation", "timestamp_start_ms", "timestamp_end_ms", "severity" },
+                    properties = new Dictionary<string, object>
+                    {
+                        ["title"] = new { type = "STRING" },
+                        ["explanation"] = new { type = "STRING" },
+                        ["timestamp_start_ms"] = new { type = "INTEGER" },
+                        ["timestamp_end_ms"] = new { type = "INTEGER" },
+                        ["severity"] = new { type = "STRING", @enum = new[] { "Critical", "Major", "Minor" } },
+                        ["scoring_impact"] = new { type = "STRING", nullable = true }
+                    }
+                }
+            },
+            ["prescribed_drills"] = new
+            {
+                type = "ARRAY",
+                items = new
+                {
+                    type = "OBJECT",
+                    required = new[] { "drill_name", "instructions", "goal" },
+                    properties = new Dictionary<string, object>
+                    {
+                        ["drill_name"] = new { type = "STRING" },
+                        ["instructions"] = new { type = "STRING" },
+                        ["goal"] = new { type = "STRING" }
+                    }
+                }
+            }
+        }
+    };
+
+    // ── JSON Deserialization Models ──────────────────────────────────────
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private record EventLoggerResponse(List<RawMatchEvent> Events);
+
+    private record CoachingJsonResponse(
+        string MatchSummary,
+        decimal TechnicalGrade,
+        string GradeLabel,
+        string? EliteTip,
+        List<CoachingJsonStrength> KeyStrengths,
+        List<CoachingJsonWeakness> CriticalWeaknesses,
+        List<CoachingJsonDrill> PrescribedDrills);
+
+    private record CoachingJsonStrength(string Title, string Explanation, long TimestampStartMs, long TimestampEndMs);
+    private record CoachingJsonWeakness(string Title, string Explanation, long TimestampStartMs, long TimestampEndMs, string Severity, string? ScoringImpact);
+    private record CoachingJsonDrill(string DrillName, string Instructions, string Goal);
+}

--- a/docs/appsettings.json
+++ b/docs/appsettings.json
@@ -1,0 +1,46 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.EntityFrameworkCore": "Warning"
+      }
+    },
+    "WriteTo": [
+      { "Name": "Console" }
+    ]
+  },
+  "AllowedHosts": "*",
+  "Gcs": {
+    "BucketName": "bjj-match-analysis-v2"
+  },
+  "VertexAi": {
+    "ProjectId": "project-afa815fe-26c6-40c3-a8b",
+    "Region": "us-central1",
+    "Pipeline": {
+      "Phase1_AutoProfiler": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Temperature": 0.1,
+        "ThinkingBudgetTokens": 8192
+      },
+      "Phase2_EventLogger": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Temperature": 0.2,
+        "FpsRate": 3,
+        "ThinkingBudgetTokens": 16384
+      },
+      "Phase3_EventVerifier": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Temperature": 0.1,
+        "ThinkingBudgetTokens": 4096
+      },
+      "Phase4_HeadCoach": {
+        "ModelId": "gemini-3.1-pro-preview",
+        "Temperature": 0.4,
+        "ThinkingBudgetTokens": 16384
+      },
+      "ContextCacheTtlMinutes": 30
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Ports the proven **MyCoach mobile 4-phase agentic VLM pipeline** into CodeJitsu's web video-analysis, replacing the single-shot Gemini call. The v1 single-shot path stays behind a flag; **v2 is the default**.

Pipeline: **Auto-Profiler (+ Vertex context cache) → Event Logger → Event Verifier → Head Coach**. Produces a Visual DNA, ms-timestamped match events (actor / technique / position-flow / outcome / confidence), and a coaching report (strengths & weaknesses with severity + IBJJF scoring impact, 3 prescribed drills, 0–100 technical grade, elite tip).

## Backend (`VideoAnalysis.Server` + `SharedEntities`)
- **`VertexRestClient`** — `generateContent` + `cachedContents` create/delete via keyless ADC. Context caching on the **GLOBAL endpoint** (`locations/global/cachedContents`), matching the proven mobile implementation.
- **`AgenticPipelineService`** orchestrator — per-phase prompts + `responseSchema`s, cache create-in-P1 / reuse / delete-in-`finally` with graceful per-phase `gs://` fallback, SignalR per-phase status.
- New EF entities **`MatchEvent`**, **`CoachingReport`** (+ strengths/weaknesses/drills) and new `AiAnalysisResult` columns; migration `AddAgenticPipelineEntities` (**already applied to Supabase** — additive only).
- Read/write services (full editable parity), `PipelineDtos`, dedicated **`vertex-pipeline`** Hangfire queue, 4 new endpoints: `analyze-v2`, `GET/PATCH analysis-v2`, `status`.
- `VertexAi:Pipeline` config (Options pattern); flags `VertexAi:Pipeline:Enabled` + `VITE_ANALYSIS_V2_ENABLED`.

## Frontend (`CodeJitsu.Client`)
- Editable **V2 UI** (`v2/` components): match-event timeline, coaching tab, drills, grade gauge, low-confidence flag — all inline-editable + PATCH save.
- **`VideoPlayer`**: non-breaking `seekToMs` + actor-colored ms markers (legacy `HH:mm:ss` path untouched).
- Per-phase SignalR progress; v2-default upload trigger; en/pl i18n.

## Tests
- Backend: **151 pass / 6 skip** (16 new). Frontend: **99 pass** (6 new). `tsc --noEmit` clean.

## Verified
- Migration applied to Supabase (additive). ADC/Vertex confirmed on **MyCoach** (VM SA `codejitsu-vm-runtime@project-afa815fe-...` + `GOOGLE_CLOUD_PROJECT_ID`), not the old project.

## Remaining (post-merge)
- CI/CD run on `feature/gcp-vm-deploy` after merge.
- Real upload → pipeline → review E2E on the VM; confirm `gemini-3.1-pro-preview` `cachedContents` on global (already proven for the mobile app).

## Notes
- `docs/` includes the MyCoach mobile PRD + `VertexAiService` reference as provenance for the caching endpoint & schemas (no secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)