### PR TITLE
fix(video-upload): direct-to-GCS upload for large files (>100MB)

### DIFF
--- a/CodeJitsu.Client/src/components/VideoAnalysisEditor/VideoUploadForm.tsx
+++ b/CodeJitsu.Client/src/components/VideoAnalysisEditor/VideoUploadForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { uploadVideoFile } from '@/services/api';
+import { uploadVideoDirect } from '@/services/api';
 import { Button } from '../ui/button';
 import { VideoUploadResponse, MartialArt } from '@/types/global';
 import { Input } from '../ui/input';
@@ -52,7 +52,8 @@ const VideoUploadForm = ({
         setProgress(0);
 
         try {
-            const response: VideoUploadResponse = await uploadVideoFile({
+            // Direct-to-GCS upload (handles multi-GB files; bypasses Cloudflare's 100MB cap).
+            const response: VideoUploadResponse = await uploadVideoDirect({
                 file,
                 description,
                 studentIdentifier,
@@ -65,16 +66,7 @@ const VideoUploadForm = ({
             setDescription('');
             setStudentIdentifier('');
             setMartialArt(MartialArt.None);
-
-            if (response.statusCode == 409 && response.message !== null) {
-                toast({
-                    title: "Duplicate Video Detected",
-                    description: response.message,
-                    variant: "destructive"
-                });
-                return;
-            }
-            setSignedUrl(response.signedUrl || '')
+            setSignedUrl('');
             onUploadSuccess(response);
         } catch (err: any) {
             setError(err);

--- a/CodeJitsu.Client/src/services/api.ts
+++ b/CodeJitsu.Client/src/services/api.ts
@@ -396,6 +396,54 @@ interface VideoUploadResponse {
     signedUrl: string;
     isDuplicate?: boolean;
 }
+// ── Direct-to-GCS upload (bypasses Cloudflare's 100MB cap + the app server) ──
+
+export async function requestVideoUploadUrl({
+    file, description, studentIdentifier, martialArt, jwtToken, hydrate, currentTry = 0,
+}): Promise<{ videoId: number; uploadUrl: string; gcsPath: string }> {
+    const response = await fetch('/vid/api/video/upload-url', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${jwtToken}` },
+        body: JSON.stringify({
+            fileName: file.name,
+            contentType: file.type || 'video/mp4',
+            description,
+            studentIdentifier,
+            martialArt,
+        }),
+    });
+    if (response.ok) return await response.json();
+    if (response.status === 401 && currentTry === 0) {
+        await hydrate();
+        return await requestVideoUploadUrl({ file, description, studentIdentifier, martialArt, jwtToken, hydrate, currentTry: 1 });
+    }
+    throw new Error(`Failed to get upload URL: ${response.status} ${response.statusText}`);
+}
+
+export async function uploadFileToSignedUrl({ uploadUrl, file, onProgress }): Promise<void> {
+    // PUT the bytes straight to storage.googleapis.com. No Authorization header (the signed URL
+    // carries auth in its query string); Content-Type is sent but not signed.
+    await axios.put(uploadUrl, file, {
+        headers: { 'Content-Type': file.type || 'video/mp4' },
+        maxContentLength: Infinity,
+        maxBodyLength: Infinity,
+        onUploadProgress: (progressEvent: any) => {
+            if (onProgress && progressEvent.total) {
+                onProgress(Math.round((progressEvent.loaded * 100) / progressEvent.total));
+            }
+        },
+    });
+}
+
+/** Two-step large-file upload: request a signed URL, then PUT the file directly to GCS. */
+export async function uploadVideoDirect({
+    file, description, studentIdentifier, martialArt, jwtToken, hydrate, onProgress,
+}): Promise<VideoUploadResponse> {
+    const { videoId, uploadUrl } = await requestVideoUploadUrl({ file, description, studentIdentifier, martialArt, jwtToken, hydrate });
+    await uploadFileToSignedUrl({ uploadUrl, file, onProgress });
+    return { videoId } as VideoUploadResponse;
+}
+
 export async function uploadVideoFile({
     file,
     description,

--- a/VideoAnalysis.Server/Controllers/VideoController.cs
+++ b/VideoAnalysis.Server/Controllers/VideoController.cs
@@ -169,6 +169,50 @@ namespace VideoAnalysis.Server.Controllers
             return Ok(new { VideoId = uploadedVideo.Id, SignedUrl = signedUrl });
         }
 
+        /// <summary>
+        /// Returns a signed URL the client uses to PUT the video DIRECTLY to GCS, bypassing
+        /// Cloudflare's 100 MB body cap and the app server entirely. Creates the VideoMetadata row
+        /// up front; the client uploads the bytes, then triggers analysis with the returned VideoId.
+        /// </summary>
+        [HttpPost("upload-url")]
+        [Authorize]
+        public async Task<IActionResult> RequestUploadUrlAsync([FromBody] UploadUrlRequest request)
+        {
+            if (request is null || string.IsNullOrWhiteSpace(request.FileName))
+                return BadRequest(new { Message = "FileName is required." });
+            if (!IsValidVideoFormat(request.ContentType))
+                return BadRequest(new { Message = "Invalid video format. Allowed: mp4, avi, mov, mpeg, webm." });
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null)
+                return Unauthorized();
+
+            var dbContext = _serviceProvider.CreateScope().ServiceProvider.GetRequiredService<MyDatabaseContext>();
+
+            // Same object-name convention as UploadFileAsync; the signer encodes it into the URL.
+            var objectName = $"{Guid.NewGuid()}_{request.FileName}";
+            var gcsPath = $"gs://{_gcsService.BucketName}/{objectName}";
+
+            var uploadedVideo = new VideoMetadata
+            {
+                UserId = userId,
+                FilePath = gcsPath,
+                Description = request.Description,
+                StudentIdentifier = request.StudentIdentifier,
+                MartialArt = request.MartialArt,
+                UploadedAt = DateTime.UtcNow,
+                Type = VideoType.StudentUpload,
+            };
+            dbContext.Videos.Add(uploadedVideo);
+            await dbContext.SaveChangesAsync();
+
+            // 2h window: a multi-GB upload must START before this expires (GCS validates at request receipt).
+            var uploadUrl = await _gcsService.GenerateUploadUrlAsync(objectName, TimeSpan.FromHours(2));
+
+            _logger.LogInformation("Issued direct-upload URL for VideoId {VideoId} ({Object})", uploadedVideo.Id, objectName);
+            return Ok(new { VideoId = uploadedVideo.Id, UploadUrl = uploadUrl, GcsPath = gcsPath });
+        }
+
         [HttpPost("upload-demonstration")]
         [Authorize]
         [RequestSizeLimit(300 * 1024 * 1024)]

--- a/VideoAnalysis.Server/Domain/GoogleCloudStorageService/GoogleCloudStorageService.cs
+++ b/VideoAnalysis.Server/Domain/GoogleCloudStorageService/GoogleCloudStorageService.cs
@@ -9,8 +9,12 @@ namespace VideoAnalysis.Server.Domain.GoogleCloudStorageService
     {
         Task<string> UploadFileAsync(Stream fileStream, string fileName, string contentType);
         Task<string> GenerateSignedUrlAsync(string filePath, TimeSpan expiration);
+        /// <summary>Generates a V4 signed URL the browser can PUT a file directly to (bypasses the app server / Cloudflare).</summary>
+        Task<string> GenerateUploadUrlAsync(string objectName, TimeSpan expiration);
         Task DeleteFileAsync(string filePath);
         Task<string> CalculateFileHashAsync(Stream fileStream);
+        /// <summary>The configured GCS bucket name.</summary>
+        string BucketName { get; }
     }
 
     public class GoogleCloudStorageService : IGoogleCloudStorageService
@@ -25,6 +29,8 @@ namespace VideoAnalysis.Server.Domain.GoogleCloudStorageService
             _storageClient = StorageClient.Create(_credential);
             _bucketName = Global.AccessAppEnvironmentVariable(AppEnvironmentVariables.GoogleCloudBucketName);
         }
+
+        public string BucketName => _bucketName;
 
         // Use a mounted service-account key when one is present; otherwise fall back to
         // Application Default Credentials (the GCE VM's attached service account). ADC keeps us
@@ -62,7 +68,17 @@ namespace VideoAnalysis.Server.Domain.GoogleCloudStorageService
             var urlSigner = UrlSigner.FromCredential(_credential);
             return await urlSigner.SignAsync(_bucketName, objectName, expiration, HttpMethod.Get);
         }
-        
+
+        /// <inheritdoc/>
+        public async Task<string> GenerateUploadUrlAsync(string objectName, TimeSpan expiration)
+        {
+            // V4 signed PUT URL — same keyless signBlob path as the GET signer. Content-Type is NOT
+            // a signed header, so the browser may send any Content-Type; GCS stores the object with it.
+            var urlSigner = UrlSigner.FromCredential(_credential);
+            return await urlSigner.SignAsync(_bucketName, objectName, expiration, HttpMethod.Put);
+        }
+
+
         /// <inheritdoc/>
         public async Task DeleteFileAsync(string filePath)
         {

--- a/VideoAnalysis.Server/Models/Dtos/VideoAnalysisDtos.cs
+++ b/VideoAnalysis.Server/Models/Dtos/VideoAnalysisDtos.cs
@@ -44,6 +44,19 @@ namespace VideoAnalysis.Server.Models.Dtos
         public MartialArt MartialArt { get; set; }
     }
 
+    /// <summary>
+    /// Request for a direct-to-GCS signed upload URL. The client PUTs the file bytes straight to
+    /// GCS (bypassing Cloudflare + the app server), so there is no 100 MB body limit.
+    /// </summary>
+    public class UploadUrlRequest
+    {
+        public required string FileName { get; set; }
+        public required string ContentType { get; set; }
+        public string? Description { get; set; }
+        public string? StudentIdentifier { get; set; }
+        public MartialArt MartialArt { get; set; }
+    }
+
     public class TechniqueDto
     {
         public int? Id { get; set; }


### PR DESCRIPTION
## Problem
Uploading a real BJJ competition tape (800 MB; tapes run 2–4 GB) stalls at **0%**. Root cause confirmed from the VM logs: the request never reaches the VM. The web app uploads the **whole file through Cloudflare → nginx → the container**, and **Cloudflare free/Pro hard-caps request bodies at 100 MB** (plus nginx `client_max_body_size 100M`). No nginx tuning can lift the Cloudflare cap.

Ruled out: not RAM/OOM (1.2 GiB free, no OOM events), not a container crash (all `Up`, `video-analysis` at ~148 MB).

## Fix — direct-to-GCS signed-URL upload
Matches the MyCoach mobile PRD §7.1. The browser PUTs the file **straight to `storage.googleapis.com`**, bypassing Cloudflare, nginx, and the VM — so there's no size limit and no VM memory/bandwidth load.

**Backend**
- `GoogleCloudStorageService.GenerateUploadUrlAsync` — V4 signed **PUT** URL (same keyless `signBlob` path as the existing GET signer) + `BucketName`.
- `POST /api/video/upload-url` — creates the `VideoMetadata` row, returns `{ videoId, uploadUrl }`.

**Frontend**
- `requestVideoUploadUrl` + `uploadFileToSignedUrl`; `VideoUploadForm` now: get signed URL → `axios.put` the file to GCS (with progress) → trigger analysis with `videoId`.

## ⚠️ Required before this works: one-time bucket CORS
The browser PUT is cross-origin, so `martial-art-demo-vids` needs a CORS policy allowing PUT from the site origin (preflight fails otherwise). Run once:
\`\`\`bash
cat > cors.json <<'JSON'
[{"origin":["https://thecodejitsu.com"],"method":["PUT","GET","HEAD"],"responseHeader":["Content-Type","x-goog-resumable"],"maxAgeSeconds":3600}]
JSON
gcloud storage buckets update gs://martial-art-demo-vids --cors-file=cors.json
\`\`\`

## Tests
Backend 22 pass / 2 skip (video + agentic); frontend 99 pass; `tsc` clean.

## Notes
- The legacy `upload-sparring` multipart endpoint is left intact (unused by the form now).
- Server-side hash dedup doesn't apply on the direct path (server never sees the bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)